### PR TITLE
Add Ukrainian translation

### DIFF
--- a/po/LINGUAS
+++ b/po/LINGUAS
@@ -3,3 +3,4 @@ it
 ru
 es
 nl
+uk

--- a/po/uk.po
+++ b/po/uk.po
@@ -1,6 +1,6 @@
-# Ukrainian translation for Gear Level.
-# Copyright (C) 2023 THE Gear Level'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the Gear Level package.
+# Ukrainian translation for Gear Lever.
+# Copyright (C) 2023 THE Gear Lever'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the Gear Lever package.
 # volkov <volkovissocool@gmail.com>, 2023.
 #
 msgid ""

--- a/po/uk.po
+++ b/po/uk.po
@@ -1,0 +1,361 @@
+# Ukrainian translation for Gear Level.
+# Copyright (C) 2023 THE Gear Level'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the Gear Level package.
+# volkov <volkovissocool@gmail.com>, 2023.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-08-17 12:36+0200\n"
+"PO-Revision-Date: 2023-09-22 17:51+0300\n"
+"Last-Translator: volkov <volkovissocool@gmail.com>\n"
+"Language-Team: \n"
+"Language: uk\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.3.1\n"
+
+#: data/it.mijorus.gearlever.desktop.in:3
+msgid "Gear lever"
+msgstr "Gear lever"
+
+#: src/main.py:93
+msgid "translator_credits"
+msgstr "volkov <volkovissocool@gmail.com>"
+
+#: src/AppDetails.py:53
+msgid "I have verified the source of this app"
+msgstr "Я перевірив джерело цього додатку"
+
+#: src/AppDetails.py:158
+msgid "Path"
+msgstr "Шлях"
+
+#: src/AppDetails.py:168
+msgid "Website"
+msgstr "Веб-сайт"
+
+#: src/AppDetails.py:168
+msgid "Add a website"
+msgstr "Додати веб-сайт"
+
+#: src/AppDetails.py:174
+msgid "Open URL"
+msgstr "Відкрити URL-посилання"
+
+#: src/AppDetails.py:184
+msgid "Reload metadata"
+msgstr "Перезавантажити метадані"
+
+#: src/AppDetails.py:185
+msgid ""
+"Update information like icon, version and description.\n"
+"Useful if the app updated itself."
+msgstr ""
+"Оновити інформацію, таку як: піктограму, версію і опис.\n"
+"Корисно, якщо додаток оновився самостійно."
+
+#: src/AppDetails.py:200
+msgid ""
+"This app is located outside the default folder\n"
+"<small>You can hide external apps in the settings</small>"
+msgstr ""
+"Цей додаток знаходиться за межами стандартної теки\n"
+"<small>Ви можете сховати додатки за межами теки у налаштуваннях</small>"
+
+#: src/AppDetails.py:276
+msgid "Launching..."
+msgstr "Запускаємо..."
+
+#: src/AppDetails.py:306
+msgid "This app runs in the terminal"
+msgstr "Цей додаток запущено у терміналі"
+
+#: src/AppDetails.py:310 src/AppDetails.py:327
+msgid "Launch"
+msgstr "Запустити"
+
+#: src/AppDetails.py:313 src/AppDetails.py:334
+msgid "Remove"
+msgstr "Видалити"
+
+#: src/AppDetails.py:317
+msgid "Uninstalling..."
+msgstr "Видаляємо..."
+
+#: src/AppDetails.py:320
+msgid "Installing..."
+msgstr "Встановлюємо..."
+
+#: src/AppDetails.py:326
+msgid "Move to the app menu"
+msgstr "Пересунути у меню додатків"
+
+#: src/AppDetails.py:330
+msgid "Update"
+msgstr "Оновити"
+
+#: src/AppDetails.py:338
+msgid "Updating"
+msgstr "Оновлюємо"
+
+#: src/AppDetails.py:341
+msgid "Error"
+msgstr "Помилка"
+
+#: src/GearleverWindow.py:35
+msgid "Open a new AppImage"
+msgstr "Відкрити новий AppImage"
+
+#: src/GearleverWindow.py:201
+msgid "Open a file"
+msgstr "Відкрити файл"
+
+#: src/InstalledAppsList.py:36
+msgid "Filter installed applications"
+msgstr "Сортувати встановлені додатки"
+
+#: src/InstalledAppsList.py:41
+msgid "Installed applications"
+msgstr "Встановлені додатки"
+
+#: src/preferences.py:22
+msgid "General"
+msgstr "Загальні"
+
+#: src/preferences.py:27
+msgid "AppImage default location"
+msgstr "Стандартна тека для додатків AppImage"
+
+#: src/preferences.py:36
+msgid "Use executable name for integrated terminal apps"
+msgstr ""
+"Використовувати назву виконувального файлу для інтеграції термінальних "
+"додатків"
+
+#: src/preferences.py:38
+msgid ""
+"If enabled, apps that run in the terminal are renamed as their executable.\n"
+"You would need to add the aforementioned folder to your $PATH manually.\n"
+"\n"
+"For example, \"golang_x86_64.appimage\" will be saved as \"go\""
+msgstr ""
+"Якщо ввімкнено, програми, які запускаються в терміналі, будуть перейменовані "
+"як їхні виконувані файли.\n"
+"Вам потрібно буде вручну додати вищезазначену теку до вашого $PATH.\n"
+"\n"
+"Наприклад, \"golang_x86_64.appimage\" буде збережено як \"go\""
+
+#: src/preferences.py:42
+msgid "Show integrated AppImages outside the default folder"
+msgstr "Показувати інтегровані AppImage додатки за межами стандартної теки"
+
+#: src/preferences.py:44
+msgid ""
+"List AppImages that have been integrated into the system menu but are "
+"located outside the default folder"
+msgstr ""
+"Показувати AppImage додатки які були інтегровані в системне меню, але які "
+"знаходяться за межами стандартної теки"
+
+#: src/preferences.py:52
+msgid "File management"
+msgstr "Керування файлами"
+
+#: src/preferences.py:54
+msgid "Move AppImages into the destination folder"
+msgstr "Пересувати AppImage додатки у теку призначення"
+
+#: src/preferences.py:55
+msgid "Reduce disk usage"
+msgstr "Зменшує використання дискового простору"
+
+#: src/preferences.py:59
+msgid "Clone AppImages into the destination folder"
+msgstr "Клонувати AppImage додатки у теку призначення"
+
+#: src/preferences.py:60
+msgid "Keep the original file and create a copy in the destination folder"
+msgstr "Зберегти оригінальний файл і створити його копію у теці призначення"
+
+#: src/preferences.py:85
+msgid "Debugging"
+msgstr "Налагодження"
+
+#: src/preferences.py:87
+msgid "Enable debug logs"
+msgstr "Увімкнути звіти налагодження додатку"
+
+#: src/preferences.py:89
+msgid ""
+"Increases log verbosity, occupying more disk space and potentially impacting "
+"performance.\n"
+"Requires a restart."
+msgstr ""
+"Збільшує детальність звітів, через що вони будуть займати більше місця на "
+"диску і потенційно впливати на продуктивність додатку.\n"
+"Щоб ця опція вступила в силу, треба перезавантажити додаток."
+
+#: src/preferences.py:112 src/WelcomeScreen.py:90
+msgid "The folder must be in your home directory"
+msgstr "Ця тека повинна бути у вашій \"Домівка\" теці"
+
+#: src/preferences.py:115 src/WelcomeScreen.py:93
+msgid "Select a folder"
+msgstr "Обрати теку"
+
+#: src/gtk/main-menu.ui:6
+msgid "_Preferences"
+msgstr "_Налаштування"
+
+#: src/gtk/main-menu.ui:10
+msgid "_Open Log File"
+msgstr "Відкрити файл _звітування"
+
+#: src/gtk/main-menu.ui:14
+msgid "_Show tutorial"
+msgstr "Показати _інструкції"
+
+#: src/gtk/main-menu.ui:18
+msgid "_About Gear lever"
+msgstr "_Про Gear lever"
+
+#: src/components/AppDetailsConflictModal.py:10
+#, python-brace-format
+msgid "Conflict with \"{app_name}\""
+msgstr "Конфлікт з \"{app_name}\""
+
+#: src/components/AppDetailsConflictModal.py:11
+msgid "There is already an app with the same name, how do you want to proceed?"
+msgstr "Вже встановлено додаток з таким же ім'ям. Як ви бажаєте це вирішити?"
+
+#: src/components/AppDetailsConflictModal.py:14
+msgid "Cancel"
+msgstr "Скасувати"
+
+#: src/components/AppDetailsConflictModal.py:17
+msgid "Keep both"
+msgstr "Зберегти обидва"
+
+#: src/components/AppDetailsConflictModal.py:19
+msgid "Replace"
+msgstr "Замінити"
+
+#: src/gtk/drag-drop.ui:18
+msgid "Drop your file here"
+msgstr "Перетягніть ваш файл сюди"
+
+#: src/gtk/empty-list-placeholder.ui:18
+msgid "Get started"
+msgstr "Як розпочати"
+
+#: src/gtk/empty-list-placeholder.ui:30
+msgid "Drag and drop an AppImage here or click on the \"+\" icon."
+msgstr "Перетягніть AppImage додаток сюди або натисніть на \"+\" піктограму."
+
+#: src/gtk/empty-list-placeholder.ui:35
+msgid " If you don't see your apps, check if the selected folder is correct."
+msgstr ""
+" Якщо ви не бачите ващі додатки, перевірте, чи правильну теку ви обрали."
+
+#: src/gtk/empty-list-placeholder.ui:46
+msgid "Open Preferences"
+msgstr "Відкрити налаштування"
+
+#: src/gtk/help-overlay.ui:11
+msgctxt "shortcut window"
+msgid "General"
+msgstr "Загальні"
+
+#: src/gtk/help-overlay.ui:14
+msgctxt "shortcut window"
+msgid "Show Shortcuts"
+msgstr "Показати клавіатурні скорочення"
+
+#: src/gtk/help-overlay.ui:20
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "Вийти"
+
+#: src/gtk/tutorial/1.ui:21
+msgid "Hi, welcome to Gear lever"
+msgstr "Ласкаво просимо до Gear lever"
+
+#: src/gtk/tutorial/1.ui:30
+msgid "An app that helps you integrating AppImages into you system."
+msgstr ""
+"Це додаток, який допоможе вам інтегрувати AppImage додатки у вашу систему."
+
+#: src/gtk/tutorial/1.ui:36
+msgid "Click \"Next\" to follow this tutorial."
+msgstr "Натисніть \"Далі\", щоб продовжити."
+
+#: src/gtk/tutorial/2.ui:19
+msgid "Set the AppImage location"
+msgstr "Встановити теку з AppImage додатками"
+
+#: src/gtk/tutorial/2.ui:28
+msgid ""
+"Gear lever groups all your AppImages into a specific folder and keeps them "
+"organized."
+msgstr ""
+"Gear lever згрупує усі ваші AppImage додатки у обрану теку і буде сортувати "
+"їх там."
+
+#: src/gtk/tutorial/2.ui:33
+#, python-brace-format
+msgid "By default, AppImages are saved at: {location}"
+msgstr "За замовченням, AppImage зберігаються у: {location}"
+
+#: src/gtk/tutorial/2.ui:47
+msgid "Change AppImage location"
+msgstr "Змінити теку з AppImage додатками"
+
+#: src/gtk/tutorial/2.ui:59
+msgid "You can customize it later in the preferences."
+msgstr "Ви можете змінити цю опцію потім у налаштуваннях."
+
+#: src/gtk/tutorial/3.ui:19
+msgid "Set Gear lever as default"
+msgstr "Встановити Gear lever за замовченням"
+
+#: src/gtk/tutorial/3.ui:28
+msgid ""
+"Click on the button to open a demo folder, containing a sample AppImage."
+msgstr ""
+"Натисніть на кнопку, щоб відчинити теку з демонстраційним AppImage додатком."
+
+#: src/gtk/tutorial/3.ui:33
+msgid ""
+"Use the right-click menu to set Gear lever as the default app for \"."
+"appimage\" files"
+msgstr ""
+"Натиснувши правою кнопкою миші по файлу, в відкритому контекстному меню "
+"оберіть опцію, щоб зробити Gear lever стандартним додатком для відкривання "
+"\".appimage\" файлів"
+
+#: src/gtk/tutorial/3.ui:44
+msgid "Open demo folder"
+msgstr "Відкрити демонстраційну теку"
+
+#: src/gtk/tutorial/3.ui:56
+msgid "This step is optional"
+msgstr "Цей крок не обов'язковий"
+
+#: src/gtk/tutorial/last.ui:21
+msgid "All done, let's go!"
+msgstr "Все готово, можна розпочинати!"
+
+#: src/gtk/tutorial/last.ui:35
+msgid "Close tutorial"
+msgstr "Закрити інструкції"
+
+#: src/models/AppListElement.py:19
+msgid "No description provided"
+msgstr "Опис не надано"
+
+#: src/providers/AppImageProvider.py:481
+msgid "Cannot load an untrusted AppImage"
+msgstr "Неможливо завантажити ненадійний AppImage"


### PR DESCRIPTION
Sadly, forcing GNOME Builder to run app with specific language is kind of convoluted (at least, I wasn't have much luck running Gear Lever with Ukrainian locale), I wasn't able to properly test strings in context, so I'm not sure if 100% of them translated properly, but overall it should be alright.
_Workaround with setting "LANG=*locale_that_i_want_to_check*" inside executing terminal inside GNOME Builder doesn't seems to work with Gear Lever, unlike some GTK4 apps that I translated in past, so I'm not sure, what I did wrong._