### PR TITLE
I changed the default height 

### DIFF
--- a/src/GearleverWindow.py
+++ b/src/GearleverWindow.py
@@ -120,7 +120,7 @@ class GearleverWindow(Gtk.ApplicationWindow):
 
             if self.from_file:
                 # open the app with a minimal UI when opening a single file
-                self.set_default_size(500, 550)
+                self.set_default_size(500, 700)
                 self.left_button.set_visible(False)
                 self.menu_button.set_visible(False)
                 self.set_resizable(False)


### PR DESCRIPTION
Your initial window height caused the need for scrolling, and additionally, you couldn't resize the window to have the application remember the setting. I think using 700px as the new default value will look better. 
![image](https://github.com/mijorus/gearlever/assets/23406555/dc7b9dab-0c5b-4a6f-ba8c-c8c6ad5b2f78)

If I open the application with such settings, the problem doesn't occur