### PR TITLE
Don't install the file gearlever.in

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -27,4 +27,4 @@ configure_file(
   install_dir: get_option('bindir')
 )
 
-install_subdir('.', install_dir: moduledir)
+install_subdir('.', install_dir: moduledir, exclude_files: ['gearlever.in'])


### PR DESCRIPTION
When building an RPM on openSUSE it generates an error because it is marked as executable and has an invalid shebang