### PR TITLE
Fix first-run gsetting to correctly show welcome-screen on first-run.

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -75,8 +75,8 @@ class GearleverApplication(Adw.Application):
             self.win = GearleverWindow(application=self, from_file=from_file)
 
             # if True:
-            if not get_gsettings().get_boolean('first-run'):
-                get_gsettings().set_boolean('first-run', True)
+            if get_gsettings().get_boolean('first-run'):
+                get_gsettings().set_boolean('first-run', False)
                 tutorial = WelcomeScreen(self.pkgdatadir)
                 tutorial.present()
 


### PR DESCRIPTION
Check if first-run is true, if it is, open the welcome-screen and set first-run to false. The downside of this is because the setting is initially true, those who update will get the welcome-screen before it can be set to false.