### PR TITLE
Add a check to avoid copying the demo.AppImage file multiple times

### DIFF
--- a/src/WelcomeScreen.py
+++ b/src/WelcomeScreen.py
@@ -48,15 +48,18 @@ class WelcomeScreen(Gtk.Window):
 
         container.append(self.carousel)
 
-        self.demo_folder = GLib.get_user_cache_dir() + f'/{APP_ID}/demo'
-        if not os.path.exists(self.demo_folder):
-            os.makedirs(self.demo_folder)
+        self.demo_folder = os.path.join(GLib.get_user_cache_dir(), APP_ID, 'demo')
+        demo_app = Gio.File.new_for_path(os.path.join(pkgdatadir, APP_NAME, 'assets', 'demo.AppImage'))
+        demo_app_dest = os.path.join(self.demo_folder, demo_app.get_basename())
 
-        # move the demo appimage into a temp folder
-        demo_app = Gio.File.new_for_path(f'{pkgdatadir}/{APP_NAME}/assets/demo.AppImage')
-        gio_copy(demo_app, Gio.File.new_for_path(f'{self.demo_folder}/demo.AppImage'))
+        # if the demo file exists, the path to it exists so we can skip checking both
+        if not os.path.exists(demo_app_dest):
+            # create paths to demo file if the path does not exist
+            os.makedirs(self.demo_folder, exist_ok=True)
+            # move demo file to the demo_folder
+            gio_copy(demo_app, Gio.File.new_for_path(demo_app_dest))
+            logging.debug(f'Copied demo app into {self.demo_folder}')
 
-        logging.debug(f'Copied demo app into {self.demo_folder}')
         third_page.get_object('open-demo-folder').connect('clicked', self.on_open_demo_folder_clicked)
         second_page.get_object('open-preferences').connect('clicked', self.on_default_localtion_btn_clicked)
 


### PR DESCRIPTION
The welcome screen checks if the path to the demo.AppImage file in the user's cache directory exists but not if the demo file itself exists. 

To avoid copying the demo file multiple times, I rolled both in to one check (if the file exists then the path to it exists so we can skip both making the directories and copying the file). As well as using `os.makedirs(... exist_ok=True)` to skip making the directories if it exists inside this check without the need to use an additional if statement. 

I also added in `os.path.join()` to my demo_app_dest variable so I changed those around this part for consistency.