### PR TITLE
Produce an error log if libfuse is not installed

### DIFF
--- a/src/lib/terminal.py
+++ b/src/lib/terminal.py
@@ -41,7 +41,7 @@ def host_threaded_sh(command: List[str], callback: Optional[Callable[[str], None
             output = host_sh(command, return_stderr)
 
             if callback:
-                callback(re.sub(r'\n$', '', output))
+                callback(output)
 
         except subprocess.CalledProcessError as e:
             logging.error(e.stderr)

--- a/src/lib/utils.py
+++ b/src/lib/utils.py
@@ -153,3 +153,8 @@ def remove_special_chars(filename, replacement=""):
     # Regular expression to match special characters (excluding alphanumeric, underscore, and dot)
     pattern = r"[^\w\._]+"
     return re.sub(pattern, replacement, filename)
+
+def log_command_output(output):
+    output = output.replace('\n', '')
+    if "libfuse" in output:
+        logging.error(output)

--- a/src/lib/utils.py
+++ b/src/lib/utils.py
@@ -7,6 +7,7 @@ import gi
 import hashlib
 
 from .costants import APP_ID
+from .async_utils import idle
 
 gi.require_version('Gtk', '4.0')
 gi.require_version('Adw', '1')
@@ -154,7 +155,19 @@ def remove_special_chars(filename, replacement=""):
     pattern = r"[^\w\._]+"
     return re.sub(pattern, replacement, filename)
 
-def log_command_output(output):
-    output = output.replace('\n', '')
-    if "libfuse" in output:
+@idle
+def command_output_error(output):
+    if 'libfuse' in output:
+        output = output.replace('\n', '')
         logging.error(output)
+
+        dialog = Adw.MessageDialog(
+            transient_for=get_application_window(),
+            heading=_('Error')
+        )
+
+        dialog.set_body(f'AppImages require FUSE to run. You might still be able to run it with --appimage-extract-and-run in the command line arguments. \n\nClick the link below for more information. \n<a href="https://github.com/AppImage/AppImageKit/wiki/FUSE">https://github.com/AppImage/AppImageKit/wiki/FUSE</a>')
+        dialog.set_body_use_markup('True')
+        dialog.add_response('okay', _('Okay'))
+
+        dialog.present()

--- a/src/providers/AppImageProvider.py
+++ b/src/providers/AppImageProvider.py
@@ -13,7 +13,7 @@ import dataclasses
 from ..lib import terminal
 from ..models.AppListElement import AppListElement, InstalledStatus
 from ..lib.async_utils import _async
-from ..lib.utils import log, get_giofile_content_type, get_gsettings, gio_copy, get_file_hash, remove_special_chars, log_command_output
+from ..lib.utils import log, get_giofile_content_type, get_gsettings, gio_copy, get_file_hash, remove_special_chars, command_output_error
 from ..models.Models import FlatpakHistoryElement, AppUpdateElement, InternalError
 from typing import Optional, List, TypedDict
 from gi.repository import GLib, Gtk, Gdk, Gio
@@ -232,18 +232,18 @@ class AppImageProvider():
 
                 if gtk_launch and el.desktop_file_path:
                     desktop_file_name = os.path.basename(el.desktop_file_path)
-                    terminal.host_threaded_sh(['gtk-launch', desktop_file_name], callback=log_command_output, return_stderr=True)
+                    terminal.host_threaded_sh(['gtk-launch', desktop_file_name], callback=command_output_error, return_stderr=True)
                 else:
                     cmd = shlex.split(el.desktop_entry.getExec())
                     cmd = [i for i in cmd if i not in desktop_exec_codes]
-                    terminal.host_threaded_sh(cmd, callback=log_command_output, return_stderr=True)
+                    terminal.host_threaded_sh(cmd, callback=command_output_error, return_stderr=True)
             else:
                 exec_args = []
                 if el.desktop_entry:
                     exec_args = shlex.split(el.desktop_entry.getExec())[1:]
                     exec_args = [i for i in exec_args if i not in desktop_exec_codes]
 
-                terminal.host_threaded_sh([el.file_path, *exec_args], callback=log_command_output, return_stderr=True)
+                terminal.host_threaded_sh([el.file_path, *exec_args], callback=command_output_error, return_stderr=True)
 
     def can_install_file(self, file: Gio.File) -> bool:
         return get_giofile_content_type(file) in self.supported_mimes

--- a/src/providers/AppImageProvider.py
+++ b/src/providers/AppImageProvider.py
@@ -13,7 +13,7 @@ import dataclasses
 from ..lib import terminal
 from ..models.AppListElement import AppListElement, InstalledStatus
 from ..lib.async_utils import _async
-from ..lib.utils import log, get_giofile_content_type, get_gsettings, gio_copy, get_file_hash, remove_special_chars
+from ..lib.utils import log, get_giofile_content_type, get_gsettings, gio_copy, get_file_hash, remove_special_chars, log_command_output
 from ..models.Models import FlatpakHistoryElement, AppUpdateElement, InternalError
 from typing import Optional, List, TypedDict
 from gi.repository import GLib, Gtk, Gdk, Gio
@@ -232,18 +232,18 @@ class AppImageProvider():
 
                 if gtk_launch and el.desktop_file_path:
                     desktop_file_name = os.path.basename(el.desktop_file_path)
-                    terminal.host_threaded_sh(['gtk-launch', desktop_file_name], return_stderr=True)
+                    terminal.host_threaded_sh(['gtk-launch', desktop_file_name], callback=log_command_output, return_stderr=True)
                 else:
                     cmd = shlex.split(el.desktop_entry.getExec())
                     cmd = [i for i in cmd if i not in desktop_exec_codes]
-                    terminal.host_threaded_sh(cmd, return_stderr=True)
+                    terminal.host_threaded_sh(cmd, callback=log_command_output, return_stderr=True)
             else:
                 exec_args = []
                 if el.desktop_entry:
                     exec_args = shlex.split(el.desktop_entry.getExec())[1:]
                     exec_args = [i for i in exec_args if i not in desktop_exec_codes]
 
-                terminal.host_threaded_sh([el.file_path, *exec_args], return_stderr=True) 
+                terminal.host_threaded_sh([el.file_path, *exec_args], callback=log_command_output, return_stderr=True)
 
     def can_install_file(self, file: Gio.File) -> bool:
         return get_giofile_content_type(file) in self.supported_mimes


### PR DESCRIPTION
Currently, if gtk-launch tries to launch the .desktop that points to an app image without fuse installed, the gtk-launch returns 0 which does not trigger an exception even if the app image returns a non-zero code. Though, if ran through gearlever without installing the app image first (skipping gtk-launch and running the app image directly), an error is still not logged through the exception in host_sh. 

I leveraged the callback feature provided in host_threaded_sh, run the callback through log_command_output to write an error log to the file but only if fuse is not installed: 
`ERROR [utils.py:160] dlopen(): error loading libfuse.so.2AppImages require FUSE to run. You might still be able to extract the contents of this AppImage if you run it with the --appimage-extract option. See https://github.com/AppImage/AppImageKit/wiki/FUSE for more information`

I filtered and only logged the libfuse error because app images could bloat the log file with their own errors not related to the functioning of gearlever itself. Hopefully this change provides some indication for users as to why their app images won't launch.