### PR TITLE
Update appdata according to the freedesktop appstream specifications, fix homepage url, switch to appstreamcli

### DIFF
--- a/data/it.mijorus.gearlever.appdata.xml.in
+++ b/data/it.mijorus.gearlever.appdata.xml.in
@@ -4,12 +4,14 @@
     <launchable type="desktop-id">it.mijorus.gearlever.desktop</launchable>
     <name>Gear Lever</name>
     <summary>Manage AppImages</summary>
-    <url type="homepage">https://mijorus.it/projects/gearlever</url>
+    <url type="homepage">https://mijorus.it/projects/gearlever/</url>
     <url type="donation">https://ko-fi.com/mijorus</url>
     <url type="bugtracker">https://github.com/mijorus/gearlever/issues</url>
     <metadata_license>CC0-1.0</metadata_license>
     <project_license>GPL-3.0-or-later</project_license>
-    <developer_name>Lorenzo Paderi</developer_name>
+    <developer id="mijorus.it">
+      <name translatable="no">Lorenzo Paderi</name>
+    </developer>
     <branding>
       <color type="primary" scheme_preference="light">#e6eaec</color>
       <color type="primary" scheme_preference="dark">#33373a</color>

--- a/data/meson.build
+++ b/data/meson.build
@@ -22,10 +22,10 @@ appstream_file = i18n.merge_file(
   install_dir: join_paths(get_option('datadir'), 'appdata')
 )
 
-appstream_util = find_program('appstream-util', required: false)
+appstream_util = find_program('appstreamcli', required: false)
 if appstream_util.found()
   test('Validate appstream file', appstream_util,
-    args: ['validate', appstream_file]
+    args: ['validate', '--no-net', appstream_file]
   )
 endif
 


### PR DESCRIPTION
The url in the appdata.xml doesn't seem to be reachable, possibly because it doesn't auto-complete to adding a "/" on the end of the link whereas a web browser does. 

```
W: it.mijorus.gearlever:7: url-not-reachable
     https://mijorus.it/projects/gearlever - Unexpected status code: 301
   Unable to reach remote location that this URL references - does it exist?
```

Simply adding a / on the end allows the link to be reachable.

The <developer_name> tag has been deprecated according to the [freedesktop appstream specifications](https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-developer). I updated to the \<developer> tag instead, made it untranslatable and use a unique id of "it.mijorus".

I believe flatpak switched to libappstream which uses `appstreamcli validate` instead of appstream-glib's `appstream-util validate` because appstream-glib is deprecated. I switched the check inside meson.build according to this which also allows a `meson test` to succeed. Also added `--no-net` to allow for offline validation, could possibly use `--explain` to allow for a more detailed explanation of any errors but it may not be needed.