### PR TITLE
Update to language pt_PT was missing from LINGUAS.po

### DIFF
--- a/po/LINGUAS
+++ b/po/LINGUAS
@@ -6,3 +6,4 @@ es
 nl
 uk
 pl_PL
+pt_PT


### PR DESCRIPTION
Given that I'm still learning about GIT and Poedit, I figured out that it was necessary to have the language name (pt_PT) added into _LINGUAS.po_.

### Side note to translators who want to test
If you are using your system in a different language than your native one (like me), and you aim to test your translation, check these steps:

1. Avoid using the Flatpak-Builder in the Flatpak version. Otherwise, you will have a hard time using arguments to _build_ and _install_ your local app.
2. After building and installing your app, you can manually override the language with the following command: `flatpak run --env=LANGUAGE=pt_PT it.mijorus.gearlever` (change pt_PT to the desired language).

At least you can avoid my mistakes and upload a proper translation :laughing: 