### PR TITLE
Clean install by removing unnecessary files through inclusion

### DIFF
--- a/data/icons/hicolor/scalable/actions/meson.build
+++ b/data/icons/hicolor/scalable/actions/meson.build
@@ -1,4 +1,27 @@
 action_dir = join_paths('hicolor', 'scalable', 'actions')
-install_subdir('.', 
+action_icons = [
+    'gearlever-check-plain-symbolic.svg',
+    'gearlever-cmd-args-symbolic.svg',
+    'gearlever-computer-symbolic.svg',
+    'gearlever-document-drop-symbolic.svg',
+    'gearlever-file-manager-symbolic.svg',
+    'gearlever-terminal-symbolic.svg',
+    'gl-application-x-executable-symbolic.svg',
+    'gl-arrow2-top-right-symbolic.svg',
+    'gl-earth-symbolic.svg',
+    'gl-funnel-outline-symbolic.svg',
+    'gl-hash-symbolic.svg',
+    'gl-info-symbolic.svg',
+    'gl-left-symbolic.svg',
+    'gl-lightbulb-symbolic.svg',
+    'gl-menu-symbolic.svg',
+    'gl-plus-symbolic.svg',
+    'gl-refresh-symbolic.svg',
+    'gl-right-symbolic.svg',
+    'gl-software-update-available-symbolic.svg',
+    'gl-star-large-symbolic.svg',
+    'gl-user-trash-symbolic.svg'
+]
+install_data(action_icons, 
     install_dir: join_paths(get_option('datadir'), 'icons', action_dir) 
 )

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,5 +1,26 @@
 pkgdatadir = join_paths(get_option('prefix'), get_option('datadir'), meson.project_name())
 moduledir = join_paths(pkgdatadir, 'gearlever')
+src_data = [
+  'AppDetails.py',
+  'BackgroudUpdatesFetcher.py',
+  'GearleverWindow.py',
+  'InstalledAppsList.py',
+  'MultiInstall.py',
+  'State.py',
+  'WelcomeScreen.py',
+  '__init__.py',
+  'main.py',
+  'preferences.py'
+]
+src_subdirs = [
+  'assets',
+  'components',
+  'gtk',
+  'lib',
+  'models',
+  'providers'
+]
+
 gnome = import('gnome')
 
 gnome.compile_resources('gearlever',
@@ -27,4 +48,8 @@ configure_file(
   install_dir: get_option('bindir')
 )
 
-install_subdir('.', install_dir: moduledir, exclude_files: ['gearlever.in'])
+install_data(src_data, install_dir: moduledir)
+
+foreach d: src_subdirs
+  install_subdir(d, install_dir: moduledir)
+endforeach

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,5 +1,13 @@
 pkgdatadir = join_paths(get_option('prefix'), get_option('datadir'), meson.project_name())
 moduledir = join_paths(pkgdatadir, 'gearlever')
+src_subdirs = [
+  'assets',
+  'components',
+  'gtk',
+  'lib',
+  'models',
+  'providers'
+]
 src_data = [
   'AppDetails.py',
   'BackgroudUpdatesFetcher.py',
@@ -11,14 +19,6 @@ src_data = [
   '__init__.py',
   'main.py',
   'preferences.py'
-]
-src_subdirs = [
-  'assets',
-  'components',
-  'gtk',
-  'lib',
-  'models',
-  'providers'
 ]
 
 gnome = import('gnome')
@@ -48,8 +48,8 @@ configure_file(
   install_dir: get_option('bindir')
 )
 
-install_data(src_data, install_dir: moduledir)
-
 foreach d: src_subdirs
   install_subdir(d, install_dir: moduledir)
 endforeach
+
+install_data(src_data, install_dir: moduledir)


### PR DESCRIPTION
Two meson.build files and I believe(?) an unneeded gearlever.gresource.xml file gets installed through meson. I avoided installing these by specifically including all other files needed providing a cleaner install. You might rather just exclude these files instead of specifically including all others and any new files:

```meson
install_subdir('.', install_dir: moduledir, exclude_files: ['gearlever.in', 'meson.build', 'gearlever.gresource.xml'])
```

up to you.