### PR TITLE
Update to Gnome 47 SDK

### DIFF
--- a/it.mijorus.gearlever.json
+++ b/it.mijorus.gearlever.json
@@ -1,7 +1,7 @@
 {
     "id" : "it.mijorus.gearlever",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "46",
+    "runtime-version" : "47",
     "sdk" : "org.gnome.Sdk",
     "command" : "gearlever",
     "finish-args" : [


### PR DESCRIPTION
It doesn't look like there is any issue with 47 Gnome Platform runtime