### PR TITLE
feat: Prepend arguments to the command that is run on appimage launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,22 @@ flatpak install --bundle --user gearlever.flatpak
   flatpak-builder build/ it.mijorus.gearlever.json --user --install --force-clean
   ```
 
+- Option #3
+  ```sh
+  # Create docker container
+  docker run --privileged -it --rm \
+    -v "$(pwd):/workspace" \
+    -w /workspace \
+    -u $(id -u ${USER}):$(id -g ${USER}) \
+    bilelmoussaoui/flatpak-github-actions:gnome-47 bash
+
+  # Run the app
+  flatpak-builder build/ it.mijorus.gearlever.json --user --force-clean
+  flatpak-builder --run build/ it.mijorus.gearlever.json gearlever
+
+  # Exit the container
+  exit
+
+  # Install the app
+  flatpak-builder build/ it.mijorus.gearlever.json --user --install --force-clean
+  ```

--- a/src/providers/AppImageProvider.py
+++ b/src/providers/AppImageProvider.py
@@ -554,6 +554,10 @@ class AppImageProvider():
 
             if env_vars:
                 env_vars = f'env {env_vars} '
+                
+            if exec_arguments.__contains__('%command%'):
+                exec_arguments = exec_arguments.replace('%command%', tryexec_command)
+                tryexec_command = ''
 
             exec_command = f'{env_vars}{tryexec_command}{exec_arguments}'
 


### PR DESCRIPTION
#211 
I didn't bother waiting :)

This PR adds the ability to prepend arguments to the run command using `%command%`, the prepended arguments are after ENV variables. Example: `taskset -c 15 %command%`.

I did consider adding another input in the GUI but decided not to since this is a pretty niche feature and I didn't want to clutter up the GUI. What are your thoughts on this @mijorus? Should I add an extra option in the GUI?