### PR TITLE
Enable 7z stderr logging

### DIFF
--- a/src/providers/AppImageProvider.py
+++ b/src/providers/AppImageProvider.py
@@ -673,11 +673,11 @@ class AppImageProvider():
 
         squashfs_root_folder = os.path.join(dest_path, 'squashfs-root')
         logging.info(f'Exctracting with p7zip to {squashfs_root_folder}')
-        z7zoutput = '=== 7z log ==='
-        z7zoutput = '\n\n' + terminal.sandbox_sh(['7z', 'x', file.get_path(), f'-o{squashfs_root_folder}', '-y', '-bso0', 'bsp0', 
+        logging.info('\n\n=== 7z log ===')
+        z7zoutput = terminal.sandbox_sh(['7z', 'x', file.get_path(), f'-o{squashfs_root_folder}', '-y', '-bso0', 'bsp0', 
                                                   '*.png', '*.svg', '*.desktop', '.DirIcon', '-r'], cwd=dest_path, return_stderr=True)
 
-        logging.debug(z7zoutput)
+        logging.debug(f'{z7zoutput}=== end 7z log ===\n')
         return squashfs_root_folder
 
     def _load_appimage_metadata(self, el: AppImageListElement) -> ExtractedAppImage:

--- a/src/providers/AppImageProvider.py
+++ b/src/providers/AppImageProvider.py
@@ -675,7 +675,7 @@ class AppImageProvider():
         logging.info(f'Exctracting with p7zip to {squashfs_root_folder}')
         z7zoutput = '=== 7z log ==='
         z7zoutput = '\n\n' + terminal.sandbox_sh(['7z', 'x', file.get_path(), f'-o{squashfs_root_folder}', '-y', '-bso0', 'bsp0', 
-                                                  '*.png', '*.svg', '*.desktop', '.DirIcon', '-r'], cwd=dest_path)
+                                                  '*.png', '*.svg', '*.desktop', '.DirIcon', '-r'], cwd=dest_path, return_stderr=True)
 
         logging.debug(z7zoutput)
         return squashfs_root_folder

--- a/src/providers/AppImageProvider.py
+++ b/src/providers/AppImageProvider.py
@@ -674,7 +674,7 @@ class AppImageProvider():
         squashfs_root_folder = os.path.join(dest_path, 'squashfs-root')
         logging.info(f'Exctracting with p7zip to {squashfs_root_folder}')
         logging.info('\n\n=== 7z log ===')
-        z7zoutput = terminal.sandbox_sh(['7z', 'x', file.get_path(), f'-o{squashfs_root_folder}', '-y', '-bso0', 'bsp0', 
+        z7zoutput = terminal.sandbox_sh(['7z', 'x', file.get_path(), f'-o{squashfs_root_folder}', '-y', '-bso0', '-bsp0', 
                                                   '*.png', '*.svg', '*.desktop', '.DirIcon', '-r'], cwd=dest_path, return_stderr=True)
 
         logging.debug(f'{z7zoutput}=== end 7z log ===\n')


### PR DESCRIPTION
Extracting libreoffice with 7zip seems to have some issues with "dangerous" symlinks. Because arch linux switched to 7zip over p7zip, 7zip reports these errors and throws out an exit code of 2 whereas, I believe p7zip just allows it by default and moves on. Because of this, gearlever completely halts when extracting libreoffice on arch linux and throws out the below errors into terminal. Enabling return_stderr allows gearlever to continue but log the errors.

I'm unsure whether this is an issue in the libreoffice appimage but it does not seem critical to the function of gearlever or libreoffice so continuing and logging the error for future reference seemed appropriate.

Also correctly show the 7z log header and added an end log footer as seen below. Also added missing dash to bsp0 option for 7z command.
![Screenshot From 2025-02-11 12-41-56](https://github.com/user-attachments/assets/cc015d93-d4d6-48e5-9e92-3bd965d7675a)
