### PR TITLE
#83 AppImage generation with docker

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,0 +1,150 @@
+# Dockerfile for building GearLever AppImage in a clean Ubuntu 24.04 environment
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && apt-get install -y --no-install-recommends build-essential && rm -rf /var/lib/apt/lists/*
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && apt-get install -y --no-install-recommends pkg-config && rm -rf /var/lib/apt/lists/*
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && apt-get install -y --no-install-recommends libglib2.0-dev && rm -rf /var/lib/apt/lists/*
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && apt-get install -y --no-install-recommends meson && rm -rf /var/lib/apt/lists/*
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && apt-get install -y --no-install-recommends ninja-build && rm -rf /var/lib/apt/lists/*
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && apt-get install -y --no-install-recommends python3-gi && rm -rf /var/lib/apt/lists/*
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && apt-get install -y --no-install-recommends python3-pip && rm -rf /var/lib/apt/lists/*
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && apt-get install -y --no-install-recommends python3-setuptools && rm -rf /var/lib/apt/lists/*
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && apt-get install -y --no-install-recommends python3-wheel && rm -rf /var/lib/apt/lists/*
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && apt-get install -y --no-install-recommends python3-venv && rm -rf /var/lib/apt/lists/*
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && apt-get install -y --no-install-recommends python3-cairo && rm -rf /var/lib/apt/lists/*
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && apt-get install -y --no-install-recommends python3.12-dev && rm -rf /var/lib/apt/lists/*
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && apt-get install -y --no-install-recommends python3-gi-cairo && rm -rf /var/lib/apt/lists/*
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && apt-get install -y --no-install-recommends gir1.2-gtk-4.0 && rm -rf /var/lib/apt/lists/*
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && apt-get install -y --no-install-recommends libglib2.0-bin && rm -rf /var/lib/apt/lists/*
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && apt-get install -y --no-install-recommends desktop-file-utils && rm -rf /var/lib/apt/lists/*
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && apt-get install -y --no-install-recommends squashfs-tools && rm -rf /var/lib/apt/lists/*
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && apt-get install -y --no-install-recommends p7zip-full && rm -rf /var/lib/apt/lists/*
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && apt-get install -y --no-install-recommends python3-pyxdg && rm -rf /var/lib/apt/lists/*
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && apt-get install -y --no-install-recommends libdbus-1-dev && rm -rf /var/lib/apt/lists/*
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && apt-get install -y --no-install-recommends wget && rm -rf /var/lib/apt/lists/*
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && apt-get install -y --no-install-recommends gettext && rm -rf /var/lib/apt/lists/*
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && apt-get install -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/*
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && apt-get install -y --no-install-recommends libfuse2 && rm -rf /var/lib/apt/lists/*
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && apt-get install -y --no-install-recommends file && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build
+
+# Use more specific COPY instructions to avoid unnecessary rebuilds
+COPY src/ /build/src/
+COPY data/ /build/data/
+COPY build-aux/ /build/build-aux/
+COPY po/ /build/po/
+COPY meson.build requirements.txt it.mijorus.gearlever.json /build/
+
+# Ensure AppDir exists before creating AppRun
+RUN mkdir -p AppDir && \
+    echo '#!/bin/sh\nHERE="$(dirname "$(readlink -f "$0")")"\nexport PYTHONPATH="$HERE/usr/lib/python3.12/site-packages:$HERE/usr/lib/python3.12/dist-packages:$PYTHONPATH"\nexport XDG_DATA_DIRS="$HERE/usr/share:${XDG_DATA_DIRS:-/usr/local/share:/usr/share}"\nexport GSETTINGS_SCHEMA_DIR="${APPDIR}/usr/share/glib-2.0/schemas"\nexec "$HERE/usr/bin/gearlever" "$@"' > AppDir/AppRun && \
+    chmod +x AppDir/AppRun
+
+# Install Python dependencies directly into AppDir
+RUN pip3 install --prefix=$PWD/AppDir --break-system-packages -r requirements.txt
+
+ENV PATH="/build/AppDir/usr/bin:$PATH"
+
+RUN meson setup builddir --prefix=/usr && \
+    ninja -C builddir && \
+    DESTDIR=$PWD/AppDir ninja -C builddir install
+
+# Ensure GSettings schema is compiled and included in AppDir
+RUN glib-compile-schemas data/ && \
+    mkdir -p AppDir/usr/share/glib-2.0/schemas && \
+    cp data/gschemas.compiled AppDir/usr/share/glib-2.0/schemas/
+
+RUN mkdir -p AppDir/usr/share/glib-2.0/schemas
+RUN cp data/gschemas.compiled AppDir/usr/share/glib-2.0/schemas/
+
+RUN wget -O appimagetool https://github.com/AppImage/AppImageKit/releases/latest/download/appimagetool-x86_64.AppImage && \
+    chmod +x appimagetool
+
+RUN find AppDir
+RUN cp AppDir/usr/share/applications/*.desktop AppDir/ || true
+RUN cp AppDir/usr/share/icons/hicolor/scalable/apps/it.mijorus.gearlever.svg AppDir/ 2>/dev/null || true
+RUN cp AppDir/usr/share/icons/hicolor/scalable/apps/it.mijorus.gearlever.png AppDir/ 2>/dev/null || true
+RUN cp AppDir/usr/share/icons/hicolor/256x256/apps/it.mijorus.gearlever.png AppDir/ 2>/dev/null || true
+RUN cp AppDir/usr/share/icons/hicolor/256x256/apps/it.mijorus.gearlever.svg AppDir/ 2>/dev/null || true
+RUN APPIMAGE_EXTRACT_AND_RUN=1 ./appimagetool AppDir GearLever-x86_64.AppImage
+
+VOLUME /host
+# Set the default command to ensure the container exits after producing the artifact
+CMD ["/bin/bash", "-c", "cp GearLever-x86_64.AppImage /host/"]

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,34 @@
+# Docker ignore file for GearLever AppImage build
+
+# Version control files
+.git
+.gitignore
+
+# Docker files (to avoid layer cache invalidation when these change)
+.docker
+.dockerignore
+
+# Build artifacts & temporary files
+build/
+builddir/
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.pytest_cache/
+
+# Development environment
+.vscode/
+.idea/
+*.code-workspace
+
+# Documentation & non-essential files
+docs/
+README.md
+CONTRIBUTING.md
+LICENSE
+COPYING
+*.md
+
+# Testing
+tests/

--- a/.github/workflows/appimage-build.yml
+++ b/.github/workflows/appimage-build.yml
@@ -1,0 +1,30 @@
+# Updated to use the Dockerfile from .docker directory
+name: AppImage Build
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build-appimage:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Build Docker image
+        run: |
+          docker build -t gearlever-appimage -f .docker/Dockerfile .
+
+      - name: Run Docker container to build AppImage
+        run: |
+          docker run --rm -v $(pwd):/host gearlever-appimage
+
+      - name: Upload AppImage artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: GearLever-x86_64.AppImage
+          path: GearLever-x86_64.AppImage

--- a/README.md
+++ b/README.md
@@ -85,6 +85,14 @@ flatpak install --bundle --user gearlever.flatpak
   flatpak-builder build/ it.mijorus.gearlever.json --user --install --force-clean
   ```
 
+- Option #3 (AppImage)
+  ```sh
+  # Build the AppImage using Docker
+  docker build -t gearlever-appimage -f .docker/Dockerfile .
+  docker run --rm -v $(pwd):/host gearlever-appimage
+  # The AppImage will be copied to the current directory
+  ```
+
 ## Run CLI tests
 ```sh
 python3 -m unittest tests/test_cli.py

--- a/src/gearlever.in
+++ b/src/gearlever.in
@@ -27,6 +27,25 @@ VERSION = '@VERSION@'
 pkgdatadir = '@pkgdatadir@'
 localedir = '@localedir@'
 
+# --- PATCH: Try to resolve pkgdatadir relative to AppImage/AppDir ---
+def find_pkgdatadir():
+    # 1. Check if running in AppImage/AppDir context
+    appdir = os.environ.get('APPDIR')
+    if appdir:
+        candidate = os.path.join(appdir, 'usr', 'share', 'gearlever')
+        if os.path.exists(os.path.join(candidate, 'gearlever.gresource')):
+            return candidate
+    # 2. Try relative to executable
+    exe_dir = os.path.dirname(os.path.abspath(sys.argv[0]))
+    candidate = os.path.join(exe_dir, '..', 'share', 'gearlever')
+    candidate = os.path.abspath(candidate)
+    if os.path.exists(os.path.join(candidate, 'gearlever.gresource')):
+        return candidate
+    # 3. Fallback to original pkgdatadir
+    return pkgdatadir
+
+pkgdatadir = find_pkgdatadir()
+
 sys.path.insert(1, pkgdatadir)
 signal.signal(signal.SIGINT, signal.SIG_DFL)
 locale.bindtextdomain('gearlever', localedir)


### PR DESCRIPTION
Refer to discussion at:
https://github.com/mijorus/gearlever/issues/83#issuecomment-2889022248

This is a heavy prototype that get's its job done, at least as far as I am aware. I created it with a heavy help from the copilot, because in the topic of appimages, I know very little. The commands in the RUN are left in a debug format because I have been tinkering with them and adding/removing each one, so that I needed new layers. For final build it must be adjusted, of course.

Right now the .dockerignore and the github workflow is generated and I didn't even check if it is sensible.

The docker image, however, *works* and produces runnable AppImage. To test it:
```
docker build -t gearlever-appimage -f .docker/Dockerfile .
docker run --volume ./build:/host:rw gearlever-image
```
and you should have a built artifact inside the `/build` directory on your machine.

Copying from my earlier comment, what's left to do is:

1. verify that it works for others
2. verify that the generated appimage is correct and has everything it needs in correct places
3. clean up the current docker process (it is written in a debug-friendly way but probably very suboptimal for real use case)
4. write github action to automate building the appimage
5. in the matter of future work, expand with features meant to integrate the app image into the system. AFAIK there are 2 things right now which need to be supported:   
   - install and move the gear lever itself to it's own managed directory
   - make sure auto-updates work