### PR TITLE
Fix for grammar/spelling in tutorial

### DIFF
--- a/po/cs.po
+++ b/po/cs.po
@@ -417,7 +417,7 @@ msgid "Hi, welcome to Gear lever"
 msgstr "Ahoj, vítejte v aplikaci Gear Lever"
 
 #: src/gtk/tutorial/1.ui:30
-msgid "An app that helps you integrating AppImages into you system."
+msgid "An app that helps you integrate AppImages into your system."
 msgstr ""
 "Aplikace, která vám pomůže integrovat soubory AppImage do vašeho systému."
 

--- a/po/de.po
+++ b/po/de.po
@@ -425,7 +425,7 @@ msgid "Hi, welcome to Gear lever"
 msgstr "Hi, willkommen zu Gear Lever"
 
 #: src/gtk/tutorial/1.ui:30
-msgid "An app that helps you integrating AppImages into you system."
+msgid "An app that helps you integrate AppImages into your system."
 msgstr "Eine App, die hilft AppImages in das System zu integrieren"
 
 #: src/gtk/tutorial/1.ui:36

--- a/po/es.po
+++ b/po/es.po
@@ -432,7 +432,7 @@ msgid "Hi, welcome to Gear lever"
 msgstr "Hola, bienvenid@ a Gear lever"
 
 #: src/gtk/tutorial/1.ui:30
-msgid "An app that helps you integrating AppImages into you system."
+msgid "An app that helps you integrate AppImages into your system."
 msgstr "Una app que te ayudara a integrar AppImages en tu sistema."
 
 #: src/gtk/tutorial/1.ui:36

--- a/po/fi_FI.po
+++ b/po/fi_FI.po
@@ -416,7 +416,7 @@ msgid "Hi, welcome to Gear lever"
 msgstr "Hei, tervetuloa Gear leveriin"
 
 #: src/gtk/tutorial/1.ui:30
-msgid "An app that helps you integrating AppImages into you system."
+msgid "An app that helps you integrate AppImages into your system."
 msgstr "Sovellus, joka auttaa sinua integroimaan AppIrages -järjestelmään."
 
 #: src/gtk/tutorial/1.ui:36

--- a/po/fr.po
+++ b/po/fr.po
@@ -435,7 +435,7 @@ msgid "Hi, welcome to Gear lever"
 msgstr "Bonjour, bienvenue dans Levier de vitesse"
 
 #: src/gtk/tutorial/1.ui:30
-msgid "An app that helps you integrating AppImages into you system."
+msgid "An app that helps you integrate AppImages into your system."
 msgstr ""
 "Une application qui vous aide à intégrer les AppImages dans votre système."
 

--- a/po/gearlever.pot
+++ b/po/gearlever.pot
@@ -410,7 +410,7 @@ msgid "Hi, welcome to Gear lever"
 msgstr ""
 
 #: src/gtk/tutorial/1.ui:30
-msgid "An app that helps you integrating AppImages into you system."
+msgid "An app that helps you integrate AppImages into your system."
 msgstr ""
 
 #: src/gtk/tutorial/1.ui:36

--- a/po/hi.po
+++ b/po/hi.po
@@ -414,7 +414,7 @@ msgid "Hi, welcome to Gear lever"
 msgstr "नमस्ते, गियर लीवर में आपका स्वागत है"
 
 #: src/gtk/tutorial/1.ui:30
-msgid "An app that helps you integrating AppImages into you system."
+msgid "An app that helps you integrate AppImages into your system."
 msgstr "एक ऐप जो आपके सिस्टम में ऐपइमेज को एकीकृत करने में आपकी मदद करता है।"
 
 #: src/gtk/tutorial/1.ui:36

--- a/po/it.po
+++ b/po/it.po
@@ -429,7 +429,7 @@ msgid "Hi, welcome to Gear lever"
 msgstr "Ciao, benvenuto su Gear lever"
 
 #: src/gtk/tutorial/1.ui:30
-msgid "An app that helps you integrating AppImages into you system."
+msgid "An app that helps you integrate AppImages into your system."
 msgstr "Un'applicazione che aiuta a integrare le AppImages nel sistema."
 
 #: src/gtk/tutorial/1.ui:36

--- a/po/nl.po
+++ b/po/nl.po
@@ -429,7 +429,7 @@ msgid "Hi, welcome to Gear lever"
 msgstr "Hallo, welkom in Versnellingspook"
 
 #: src/gtk/tutorial/1.ui:30
-msgid "An app that helps you integrating AppImages into you system."
+msgid "An app that helps you integrate AppImages into your system."
 msgstr "Deze toepassing helpt u om AppImages te integreren in het systeem."
 
 #: src/gtk/tutorial/1.ui:36

--- a/po/oc.po
+++ b/po/oc.po
@@ -435,7 +435,7 @@ msgid "Hi, welcome to Gear lever"
 msgstr "Adieu, la benvenguda dins Maneta"
 
 #: src/gtk/tutorial/1.ui:30
-msgid "An app that helps you integrating AppImages into you system."
+msgid "An app that helps you integrate AppImages into your system."
 msgstr ""
 "Una aplicacion que vos ajuda a integrar los AppImages a vòstre sistèma."
 

--- a/po/pl_PL.po
+++ b/po/pl_PL.po
@@ -295,7 +295,7 @@ msgid "Hi, welcome to Gear lever"
 msgstr "Cześć, witaj w Przerzutce"
 
 #: src/gtk/tutorial/1.ui:30
-msgid "An app that helps you integrating AppImages into you system."
+msgid "An app that helps you integrate AppImages into your system."
 msgstr "Aplikacja, która pomaga Ci integrować AppImages z Twoim systemem."
 
 #: src/gtk/tutorial/1.ui:36

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -431,7 +431,7 @@ msgid "Hi, welcome to Gear lever"
 msgstr "Olá, bem-vindo ao Gear lever"
 
 #: src/gtk/tutorial/1.ui:30
-msgid "An app that helps you integrating AppImages into you system."
+msgid "An app that helps you integrate AppImages into your system."
 msgstr "Uma aplicação que ajuda a integrar AppImages ao seu sistema."
 
 #: src/gtk/tutorial/1.ui:36

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -441,7 +441,7 @@ msgid "Hi, welcome to Gear lever"
 msgstr "Olá, bem-vindo ao Gear lever"
 
 #: src/gtk/tutorial/1.ui:30
-msgid "An app that helps you integrating AppImages into you system."
+msgid "An app that helps you integrate AppImages into your system."
 msgstr "Uma aplicação que o ajuda a integrar AppImages no seu sistema."
 
 #: src/gtk/tutorial/1.ui:36

--- a/po/ru.po
+++ b/po/ru.po
@@ -432,7 +432,7 @@ msgid "Hi, welcome to Gear lever"
 msgstr "Привет, добро пожаловать в Gear lever"
 
 #: src/gtk/tutorial/1.ui:30
-msgid "An app that helps you integrating AppImages into you system."
+msgid "An app that helps you integrate AppImages into your system."
 msgstr "Приложение для интеграции приложений AppImage в систему."
 
 #: src/gtk/tutorial/1.ui:36

--- a/po/tr.po
+++ b/po/tr.po
@@ -417,7 +417,7 @@ msgid "Hi, welcome to Gear lever"
 msgstr "Merhaba, Gear Lever'e hoş geldiniz"
 
 #: src/gtk/tutorial/1.ui:30
-msgid "An app that helps you integrating AppImages into you system."
+msgid "An app that helps you integrate AppImages into your system."
 msgstr "AppImage uygulamalarını sisteminize entegre etmenize yardımcı "
 "olan bir uygulamadır."
 

--- a/po/uk.po
+++ b/po/uk.po
@@ -431,7 +431,7 @@ msgid "Hi, welcome to Gear lever"
 msgstr "Ласкаво просимо до Gear lever"
 
 #: src/gtk/tutorial/1.ui:30
-msgid "An app that helps you integrating AppImages into you system."
+msgid "An app that helps you integrate AppImages into your system."
 msgstr ""
 "Це додаток, який допоможе вам інтегрувати AppImage додатки у вашу систему."
 

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -421,7 +421,7 @@ msgid "Hi, welcome to Gear lever"
 msgstr "你好，欢迎来到 Gear lever"
 
 #: src/gtk/tutorial/1.ui:30
-msgid "An app that helps you integrating AppImages into you system."
+msgid "An app that helps you integrate AppImages into your system."
 msgstr "一个帮助您集成 AppImages 到您的系统的应用。"
 
 #: src/gtk/tutorial/1.ui:36

--- a/src/gtk/tutorial/1.ui
+++ b/src/gtk/tutorial/1.ui
@@ -27,7 +27,7 @@
         </child>
         <child>
             <object class="GtkLabel">
-                <property name="label" translatable="yes">An app that helps you integrating AppImages into you system.</property>
+                <property name="label" translatable="yes">An app that helps you integrate AppImages into your system.</property>
                 <property name="margin-bottom">30</property>
             </object>
         </child>


### PR DESCRIPTION
It's just a small text change in the tutorial section, but this error was quite noticeable to me as a native English speaker so I thought I'd contribute a quick fix.
.

_From:_
"An app that helps you _`integrating`_ AppImages into _`you`_ system."

_To:_
"An app that helps you _`integrate`_ AppImages into _`your`_ system."

---

I feel like it's the best way to say this without changing the message a bunch, and it's probably how it was intended to come across.

The references in each translation file are fixed too. I'm concerned the inaccurate grammar might have caused small inaccuracies in some translations though, so it might be worth the translators having a quick check to see if it's fine. Regardless, I think the meaning of the sentence is 99% the same so it's probably not an issue.

I checked the whole template and it's only the 1 line that needs to be changed. The rest seems good. The build seems fine.