### PR TITLE
Move to newer Adwaita guidelines

### DIFF
--- a/src/GearleverWindow.py
+++ b/src/GearleverWindow.py
@@ -30,7 +30,7 @@ from .lib import utils
 from gi.repository import Gtk, Adw, Gio, Gdk, GLib
 
 
-class GearleverWindow(Gtk.ApplicationWindow):
+class GearleverWindow(Adw.Window):
     def __init__(self, from_file=False, **kwargs):
         super().__init__(**kwargs)
         self.from_file = from_file
@@ -64,7 +64,9 @@ class GearleverWindow(Gtk.ApplicationWindow):
         self.titlebar.pack_end(self.search_btn)
         
         self.titlebar.set_title_widget(self.view_title_widget)
-        self.set_titlebar(self.titlebar)
+
+        toolbar_view = Adw.ToolbarView()
+        toolbar_view.add_top_bar(self.titlebar)
 
         self.set_title('Gear lever')
         self.set_default_size(700, 700)
@@ -128,7 +130,8 @@ class GearleverWindow(Gtk.ApplicationWindow):
 
         toast_overlay.set_child(self.container_stack)
 
-        self.set_child(toast_overlay)
+        toolbar_view.set_content(toast_overlay)
+        self.set_content(toolbar_view)
 
         if self.settings.get_boolean('is-maximized'):
             self.maximize()

--- a/src/InstalledAppsList.py
+++ b/src/InstalledAppsList.py
@@ -257,4 +257,4 @@ class InstalledAppsList(Gtk.ScrolledWindow):
 
     def on_open_welcome_screen(self, widget):
         tutorial = WelcomeScreen()
-        tutorial.present()
+        tutorial.present(self)

--- a/src/gtk/tutorial/1.ui
+++ b/src/gtk/tutorial/1.ui
@@ -1,41 +1,50 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
-    <requires lib="gtk" version="4.0" />
-    <object class="GtkBox" id="target">
-        <property name="orientation">1</property>
-        <property name="valign">3</property>
-        <property name="halign">3</property>
-        <property name="hexpand">1</property>
-        <child>
-            <object class="GtkLabel">
-                <property name="label" translatable="no">👋</property>
-                <property name="margin-bottom">30</property>
-                <style>
-                    <class name="title-xl">
-                    </class>
-                </style>
-            </object>
-        </child>
-        <child>
-            <object class="GtkLabel">
-                <property name="label" translatable="yes">Hi, welcome to Gear lever</property>
-                <property name="margin-bottom">30</property>
-                <style>
-                    <class name="title-1" />
-                </style>
-            </object>
-        </child>
-        <child>
-            <object class="GtkLabel">
-                <property name="label" translatable="yes">An app that helps you integrate AppImages into your system.</property>
-                <property name="margin-bottom">30</property>
-            </object>
-        </child>
-        <child>
-            <object class="GtkLabel">
-                <property name="label" translatable="yes">Click "Next" to follow this tutorial.</property>
-                <property name="margin-bottom">30</property>
-            </object>
-        </child>
-    </object>
+ <requires lib="gtk" version="4.0" />
+ <requires lib="libadwaita" version="1.0" />
+ <object class="GtkBox" id="target">
+     <property name="orientation">1</property>
+     <property name="width-request">400</property>
+     <property name="valign">center</property>
+     <child>
+         <object class="GtkLabel">
+             <property name="halign">3</property>
+             <property name="valign">1</property>
+             <property name="label" translatable="no">👋</property>
+             <style>
+                 <class name="title-xl" />
+             </style>
+         </object>
+     </child>
+     <child>
+         <object class="GtkBox">
+             <property name="orientation">1</property>
+             <property name="spacing">12</property>
+             <property name="halign">center</property>
+             <child>
+                 <object class="GtkLabel">
+                     <property name="label" translatable="yes">Hi, welcome to Gear lever</property>
+                     <property name="halign">center</property>
+                     <style>
+                         <class name="title-1" />
+                     </style>
+                 </object>
+             </child>
+             <child>
+                 <object class="GtkLabel">
+                     <property name="label" translatable="yes">An app that helps you integrate AppImages into your system.</property>
+                     <property name="halign">center</property>
+                     <property name="justify">center</property>
+                     <property name="wrap">true</property>
+                 </object>
+             </child>
+             <child>
+                 <object class="GtkLabel">
+                     <property name="label" translatable="yes">Click "Next" to follow this tutorial.</property>
+                     <property name="halign">center</property>
+                 </object>
+             </child>
+         </object>
+     </child>
+ </object>
 </interface>

--- a/src/gtk/tutorial/2.ui
+++ b/src/gtk/tutorial/2.ui
@@ -1,67 +1,51 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
-    <requires lib="gtk" version="4.0" />
-    <object class="GtkBox" id="target">
-        <property name="orientation">1</property>
-        <property name="valign">3</property>
-        <property name="halign">3</property>
-        <property name="hexpand">1</property>
-        <child>
-            <object class="GtkImage">
-                <property name="name">logo</property>
-                <property name="icon-name">gearlever-file-manager-symbolic</property>
-                <property name="pixel-size">120</property>
-                <property name="margin-bottom">30</property>
-            </object>
-        </child>
-        <child>
-            <object class="GtkLabel">
-                <property name="label" translatable="yes">Set the AppImage location</property>
-                <property name="margin-bottom">30</property>
-                <style>
-                    <class name="title-1" />
-                </style>
-            </object>
-        </child>
-        <child>
-            <object class="GtkLabel">
-                <property name="label" translatable="yes">Gear lever groups all your AppImages into a specific folder and keeps them organized.</property>
-            </object>
-        </child>
-        <child>
-            <object class="GtkLabel" id="location-label">
-                <property name="label" translatable="yes">By default, AppImages are saved at: {location}</property>
-                <style>
-                    <class name="heading" />
-                </style>
-                <property name="margin-bottom">30</property>
-            </object>
-        </child>
-        <child>
-            <object class="GtkBox">
-                <property name="orientation">1</property>
-                <property name="valign">3</property>
-                <property name="halign">3</property>
-                <child>
-                    <object class="GtkButton" id="open-preferences">
-                        <property name="label" translatable="yes">Change AppImage location</property>
-                        <property name="margin-bottom">10</property>
-                        <property name="vexpand">0</property>
-                        <style>
-                            <class name="pill" />
-                        </style>
-                    </object>
-                </child>
-            </object>
-        </child>
-        <child>
-            <object class="GtkLabel">
-                <property name="label" translatable="yes">You can customize it later in the preferences.</property>
-                <property name="margin-bottom">30</property>
-                <style>
-                    <class name="dim-label" />
-                </style>
-            </object>
-        </child>
-    </object>
+  <requires lib="gtk" version="4.0" />
+  <requires lib="libadwaita" version="1.0" />
+  <object class="GtkBox" id="target">
+      <property name="orientation">1</property>
+      <property name="width-request">400</property>
+      <property name="valign">3</property>
+      <child>
+          <object class="AdwStatusPage">
+              <property name="icon-name">gearlever-file-manager-symbolic</property>
+              <property name="title" translatable="yes">Set the AppImage location</property>
+              <property name="description" translatable="yes">Gear lever groups all your AppImages into a specific folder and keeps them organized.</property>
+              <child>
+                  <object class="GtkBox">
+                      <property name="orientation">1</property>
+                      <property name="halign">3</property>
+                      <property name="spacing">20</property>
+                      <child>
+                          <object class="GtkLabel" id="location-label">
+                              <property name="label" translatable="yes">&lt;b&gt;By default, AppImages are saved at: {location}&lt;/b&gt;</property>
+                              <property name="use-markup">1</property>
+                              <property name="wrap">1</property>
+                              <property name="justify">2</property>
+                          </object>
+                      </child>
+                      <child>
+                          <object class="GtkButton" id="open-preferences">
+                              <property name="label" translatable="yes">Change AppImage location</property>
+                              <style>
+                                  <class name="pill" />
+                                  <class name="suggested-action" />
+                              </style>
+                          </object>
+                      </child>
+                      <child>
+                          <object class="GtkLabel">
+                              <property name="label" translatable="yes">You can customize it later in the preferences.</property>
+                              <property name="wrap">1</property>
+                              <property name="justify">2</property>
+                              <style>
+                                  <class name="dim-label" />
+                              </style>
+                          </object>
+                      </child>
+                  </object>
+              </child>
+          </object>
+      </child>
+  </object>
 </interface>

--- a/src/gtk/tutorial/3.ui
+++ b/src/gtk/tutorial/3.ui
@@ -1,64 +1,74 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
-    <requires lib="gtk" version="4.0" />
-    <object class="GtkBox" id="target">
-        <property name="orientation">1</property>
-        <property name="valign">3</property>
-        <property name="halign">3</property>
-        <property name="hexpand">1</property>
-        <child>
-            <object class="GtkImage">
-                <property name="name">logo</property>
-                <property name="icon-name">gl-star-large</property>
-                <property name="pixel-size">120</property>
-                <property name="margin-bottom">30</property>
-            </object>
-        </child>
-        <child>
-            <object class="GtkLabel">
-                <property name="label" translatable="yes">Set Gear lever as default</property>
-                <property name="margin-bottom">30</property>
-                <style>
-                    <class name="title-1" />
-                </style>
-            </object>
-        </child>
-        <child>
-            <object class="GtkLabel">
-                <property name="label" translatable="yes">Click on the button to open a demo folder, containing a sample AppImage.</property>
-            </object>
-        </child>
-        <child>
-            <object class="GtkLabel">
-                <property name="label" translatable="yes">Use the right-click menu to set Gear lever as the default app for ".appimage" files</property>
-                <property name="margin-bottom">30</property>
-            </object>
-        </child>
-        <child>
-            <object class="GtkBox">
-                <property name="orientation">1</property>
-                <property name="valign">3</property>
-                <property name="halign">3</property>
-                <child>
-                    <object class="GtkButton" id="open-demo-folder">
-                        <property name="label" translatable="yes">Open demo folder</property>
-                        <property name="margin-bottom">10</property>
-                        <property name="vexpand">0</property>
-                        <style>
-                            <class name="pill" />
-                        </style>
-                    </object>
-                </child>
-            </object>
-        </child>
-        <child>
-            <object class="GtkLabel">
-                <property name="label" translatable="yes">This step is optional</property>
-                <property name="margin-bottom">30</property>
-                <style>
-                    <class name="dim-label" />
-                </style>
-            </object>
-        </child>
-    </object>
+ <requires lib="gtk" version="4.0" />
+ <requires lib="libadwaita" version="1.0" />
+ <object class="GtkBox" id="target">
+     <property name="orientation">1</property>
+     <property name="width-request">400</property>
+     <property name="valign">3</property>
+     <child>
+         <object class="GtkBox">
+             <property name="orientation">1</property>
+             <property name="spacing">12</property>
+             <property name="halign">center</property>
+             <property name="valign">center</property>
+             <child>
+                 <object class="GtkImage">
+                     <property name="icon-name">gl-star-large</property>
+                     <property name="pixel-size">128</property>
+                 </object>
+             </child>
+             <child>
+                 <object class="GtkLabel">
+                     <property name="label" translatable="yes">Set Gear lever as default</property>
+                     <property name="halign">center</property>
+                     <style>
+                         <class name="title-1" />
+                     </style>
+                 </object>
+             </child>
+             <child>
+                 <object class="GtkLabel">
+                     <property name="label" translatable="yes">Click on the button to open a demo folder, containing a sample AppImage.</property>
+                     <property name="halign">center</property>
+                     <property name="justify">center</property>
+                     <property name="wrap">true</property>
+                 </object>
+             </child>
+             <child>
+                 <object class="GtkLabel">
+                     <property name="label" translatable="yes">Use the right-click menu to set Gear lever as the default app for ".appimage" files</property>
+                     <property name="halign">center</property>
+                     <property name="justify">center</property>
+                     <property name="wrap">true</property>
+                 </object>
+             </child>
+             <child>
+                 <object class="GtkBox">
+                     <property name="orientation">1</property>
+                     <property name="halign">3</property>
+                     <property name="spacing">10</property>
+                     <property name="margin-top">24</property>
+                     <child>
+                         <object class="GtkButton" id="open-demo-folder">
+                             <property name="label" translatable="yes">Open demo folder</property>
+                             <style>
+                                 <class name="pill" />
+                                 <class name="suggested-action" />
+                             </style>
+                         </object>
+                     </child>
+                     <child>
+                         <object class="GtkLabel">
+                             <property name="label" translatable="yes">This step is optional</property>
+                             <style>
+                                 <class name="dim-label" />
+                             </style>
+                         </object>
+                     </child>
+                 </object>
+             </child>
+         </object>
+     </child>
+ </object>
 </interface>

--- a/src/gtk/tutorial/last.ui
+++ b/src/gtk/tutorial/last.ui
@@ -1,48 +1,35 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
-    <requires lib="gtk" version="4.0" />
-    <object class="GtkBox" id="target">
-        <property name="orientation">1</property>
-        <property name="valign">3</property>
-        <property name="halign">3</property>
-        <property name="hexpand">1</property>
-        <child>
-            <object class="GtkLabel">
-                <property name="label" translatable="no">✅</property>
-                <property name="margin-bottom">30</property>
-                <style>
-                    <class name="title-xl">
-                    </class>
-                </style>
-            </object>
-        </child>
-        <child>
-            <object class="GtkLabel">
-                <property name="label" translatable="yes">All done, let's go!</property>
-                <property name="margin-bottom">30</property>
-                <style>
-                    <class name="title-1" />
-                </style>
-            </object>
-        </child>
-        <child>
-            <object class="GtkBox">
-                <property name="orientation">1</property>
-                <property name="valign">3</property>
-                <property name="halign">3</property>
-                <child>
-                    <object class="GtkButton" id="close-window">
-                        <property name="label" translatable="yes">Close tutorial</property>
-                        <property name="margin-bottom">10</property>
-                        <property name="vexpand">0</property>
-                        <style>
-                            <class name="pill" />
-                        </style>
-                    </object>
-                </child>
-            </object>
-        </child>
-    </object>
-
-
+  <requires lib="gtk" version="4.0" />
+  <requires lib="libadwaita" version="1.0" />
+  <object class="GtkBox" id="target">
+      <property name="orientation">1</property>
+      <property name="width-request">400</property>
+      <property name="valign">3</property>
+      <child>
+          <object class="GtkLabel">
+              <property name="halign">3</property>
+              <property name="valign">1</property>
+              <property name="label" translatable="no">✅</property>
+              <style>
+                  <class name="title-xl" />
+              </style>
+          </object>
+      </child>
+      <child>
+          <object class="AdwStatusPage">
+              <property name="title" translatable="yes">All done, let's go!</property>
+              <child>
+                  <object class="GtkButton" id="close-window">
+                      <property name="label" translatable="yes">Close tutorial</property>
+                      <property name="halign">3</property>
+                      <style>
+                          <class name="pill" />
+                          <class name="suggested-action" />
+                      </style>
+                  </object>
+              </child>
+          </object>
+      </child>
+  </object>
 </interface>

--- a/src/lib/utils.py
+++ b/src/lib/utils.py
@@ -61,9 +61,9 @@ def set_window_cursor(cursor: str):
             break
 
 
-def get_application_window() -> Gtk.ApplicationWindow:
+def get_application_window() -> Adw.Window:
     for w in Gtk.Window.list_toplevels():
-        if isinstance(w, Gtk.ApplicationWindow):
+        if isinstance(w, Adw.Window):
             return w
 
 

--- a/src/main.py
+++ b/src/main.py
@@ -45,9 +45,9 @@ class GearleverApplication(Adw.Application):
     def __init__(self, version, pkgdatadir):
         super().__init__(application_id=APP_ID, flags=Gio.ApplicationFlags.HANDLES_OPEN)
         self.create_action('about', self.on_about_action)
-        self.create_action('preferences', self.on_preferences_action)
+        self.create_action('preferences', self.on_preferences_action, ['<primary>comma'])
         self.create_action('open_log_file', self.on_open_log_file)
-        self.create_action('open_welcome_screen', self.on_open_welcome_screen)
+        self.create_action('open_welcome_screen', self.on_open_welcome_screen, ['F1'])
         self.win = None
         self.version = version
         self.add_main_option_entries(Cli.options)
@@ -97,7 +97,7 @@ class GearleverApplication(Adw.Application):
         self.win.on_selected_local_file(list(files))
 
     def on_about_action(self, widget, data):
-        about = Adw.AboutWindow(
+        about = Adw.AboutDialog(
             application_name='Gear Lever',
             version=self.version,
             developers=['Lorenzo Paderi'],
@@ -107,13 +107,14 @@ class GearleverApplication(Adw.Application):
         )
 
         about.set_translator_credits(_("translator_credits"))
-        about.present()
+        if self.win:
+            about.present(self.win)
 
     def on_preferences_action(self, widget, _):
         """Callback for the app.preferences action."""
         pref = Preferences()
-        pref.connect('close-request', lambda w: self.win.on_show_installed_list() if self.win else None)
-        pref.present()
+        pref.connect('closed', lambda w: self.win.on_show_installed_list() if self.win else None)
+        pref.present(self.win)
 
     def create_action(self, name, callback, shortcuts=None):
         """Add an application action.
@@ -140,7 +141,8 @@ class GearleverApplication(Adw.Application):
 
     def on_open_welcome_screen(self, widget, event):
         tutorial = WelcomeScreen()
-        tutorial.present()
+        if self.win:
+            tutorial.present(self.win)
 
 def main(version, pkgdatadir):
     """The application's entry point."""

--- a/src/preferences.py
+++ b/src/preferences.py
@@ -15,7 +15,7 @@ gi.require_version('Gtk', '4.0')
 
 from gi.repository import Adw, Gtk, Gio, GLib  # noqa
 
-class Preferences(Adw.PreferencesWindow):
+class Preferences(Adw.PreferencesDialog):
     def __init__(self, **kwargs) :
         super().__init__(**kwargs)
 


### PR DESCRIPTION
This PR applies several features suggested by the HIG that were missing:
- Making secondary dialogs modal to the main window.
- Switching from `Gtk.ApplicationWindow` to `Adw.Window`.
- Adding common shortcuts for certain actions.
- Using `Adw.StatusPage` for the tutorial.
- Moving the tutorial's next and previous buttons to an overlay for easier use, similar to GNOME Tour.