### PR TITLE
Use more compatible `POSIX` script for `get_appimage_offset.sh`

### DIFF
--- a/build-aux/get_appimage_offset.sh
+++ b/build-aux/get_appimage_offset.sh
@@ -1,11 +1,54 @@
-#!/usr/bin/bash
+#!/bin/sh
 
-ELFSIZE=$(readelf -h $1)
-START_OF_SECTION=$(echo $ELFSIZE | grep -oP "(?<=Start of section headers: )[0-9]+")
-SECTION_SIZE=$(echo $ELFSIZE | grep -oP "(?<=Size of section headers: )[0-9]+")
-SECTION_NO=$(echo $ELFSIZE | grep -oP "(?<=Number of section headers: )[0-9]+")
-APPIMG_OFFSET=$(( $START_OF_SECTION + $SECTION_SIZE * $SECTION_NO ))
+export LC_ALL=C
+offset="$(od -An -vtx1 -N 64 -- "$1" | awk '
+	BEGIN {
+		for (i = 0; i < 16; i++) {
+			c = sprintf("%x", i)
+			H[c] = i
+			H[toupper(c)] = i
+		}
+	}
+	{
+		elfHeader = elfHeader " " $0
+	}
+	END {
+		$0 = toupper(elfHeader)
+		if ($5 == "02") is64 = 1; else is64 = 0
+		if ($6 == "02") isBE = 1; else isBE = 0
+		if (is64) {
+			if (isBE) {
+				shoff = $41 $42 $43 $44 $45 $46 $47 $48
+				shentsize = $59 $60
+				shnum = $61 $62
+			} else {
+				shoff = $48 $47 $46 $45 $44 $43 $42 $41
+				shentsize = $60 $59
+				shnum = $62 $61
+			}
+			} else {
+			if (isBE) {
+				shoff = $33 $34 $35 $36
+				shentsize = $47 $48
+				shnum = $49 $50
+			} else {
+				shoff = $36 $35 $34 $33
+				shentsize = $48 $47
+				shnum = $50 $49
+			}
+		}
+		print parsehex(shoff) + parsehex(shentsize) * parsehex(shnum)
+	}
+	function parsehex(v, i, r) {
+		r = 0
+		for (i = 1; i <= length(v); i++)
+			r = r * 16 + H[substr(v, i, 1)]
+		return r
+	}'
+)"
 
-echo $APPIMG_OFFSET
-
-
+if [ -n "$offset" ]; then
+	echo "$offset"
+else
+	exit 1
+fi


### PR DESCRIPTION
Tested here by me and @Samueru-sama.

https://github.com/pkgforge-dev/Gear-Lever-AppImage

Depends on more available `od` and `awk`, while the current one depends on `readelf` and `grep`.

It's also around 8 times faster as well:  
<img width="1138" height="269" alt="517827572-17c56d47-4c6f-4b55-8abc-f0d8c50d6673" src="https://github.com/user-attachments/assets/aec10754-f539-43c8-ad55-fd922b2fc6e1" />

Simple-appimage-sandbox also uses this:  
https://github.com/Samueru-sama/simple-appimage-sandbox/