### PR TITLE
Remove one unnecessary space

### DIFF
--- a/src/gtk/empty-list-placeholder.ui
+++ b/src/gtk/empty-list-placeholder.ui
@@ -32,7 +32,7 @@
     </child>
     <child>
       <object class="GtkLabel">
-        <property name="label" translatable="yes"> If you don't see your apps, check if the selected folder is correct.</property>
+        <property name="label" translatable="yes">If you don't see your apps, check if the selected folder is correct.</property>
         <property name="margin-bottom">30</property>
       </object>
     </child>


### PR DESCRIPTION
Removed a space at the beginning of the line in the original "empty-list-placeholder.ui" file because Poedit kept nagging me about "there is a space missing here!" and none of the translations actually had a space here.