### PR TITLE
Replace non-portable arch call with native Python platform call pt. 2

### DIFF
--- a/src/AppDetails.py
+++ b/src/AppDetails.py
@@ -2,6 +2,7 @@ import time
 import logging
 import base64
 import os
+import platform
 import shlex
 from typing import Optional, Callable
 from gi.repository import Gtk, GObject, Adw, Gdk, Gio, Pango, GLib
@@ -209,7 +210,7 @@ class AppDetails(Gtk.ScrolledWindow):
         self.app_subtitle.set_visible(True)
         self.description.set_visible(True)
 
-        system_arch = sandbox_sh(['arch'])
+        system_arch = platform.machine()
 
         if self.app_list_element.installed_status is InstalledStatus.INSTALLED:
             # Exec arguments


### PR DESCRIPTION
I missed this one.

Let me know if there are other similar instances like this which need to be changed.

Related to:
https://github.com/mijorus/gearlever/pull/349