### PR TITLE
Offer more flexibility to match release file names in Updater models

### DIFF
--- a/src/models/CodebergUpdater.py
+++ b/src/models/CodebergUpdater.py
@@ -95,7 +95,7 @@ class CodebergUpdater(UpdateManager):
         regex = ""
         for char in glob_str:
             if char == "*":
-                regex += r".*"
+                regex += r"[a-zA-Z0-9]*"
             else:
                 regex += re.escape(char)
 

--- a/src/models/ForgejoUpdater.py
+++ b/src/models/ForgejoUpdater.py
@@ -103,7 +103,7 @@ class ForgejoUpdater(UpdateManager):
         regex = ""
         for char in glob_str:
             if char == "*":
-                regex += r".*"
+                regex += r"[a-zA-Z0-9]*"
             else:
                 regex += re.escape(char)
 

--- a/src/models/GithubUpdater.py
+++ b/src/models/GithubUpdater.py
@@ -125,7 +125,7 @@ class GithubUpdater(UpdateManager):
         regex = ""
         for char in glob_str:
             if char == "*":
-                regex += r".*"
+                regex += r"[a-zA-Z0-9]*"
             else:
                 regex += re.escape(char)
 

--- a/src/models/GitlabUpdater.py
+++ b/src/models/GitlabUpdater.py
@@ -110,7 +110,7 @@ class GitlabUpdater(UpdateManager):
         regex = ""
         for char in glob_str:
             if char == "*":
-                regex += r".*"
+                regex += r"[a-zA-Z0-9]*"
             else:
                 regex += re.escape(char)
 


### PR DESCRIPTION
Hello,

This PR aims at fixing #364.
In the example provided with that issue, this PR would allow differentiating the target filename in the release filename:
- `avidemux_*.*.*.appImage` would match `avidemux_2.8.1.appImage`
- `avidemux_*.*.*_legacy.appImage` would match `avidemux_2.8.1_legacy.appImage`

That would nevertheless requires most users to upgrade their configuration. If you wanted to avoid this for at least a certain number of cases, adding the dot to the regex characters class (`[a-zA-Z0-9.]`) may help.