### PR TITLE
Don't mark entire translations as fuzzy

### DIFF
--- a/po/cs.po
+++ b/po/cs.po
@@ -3,7 +3,6 @@
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"

--- a/po/de.po
+++ b/po/de.po
@@ -3,7 +3,6 @@
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/po/oc.po
+++ b/po/oc.po
@@ -3,7 +3,6 @@
 # This file is distributed under the same license as the PACKAGE package.
 # Quentin PAGÈS, 2024.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -3,7 +3,6 @@
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -3,7 +3,6 @@
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -3,7 +3,6 @@
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"


### PR DESCRIPTION
This PR fixes the Czech translation and other ones incorrectly marked as fuzzy, causing the English version to be used instead.