### PR TITLE
Improved connection check

### DIFF
--- a/src/AppDetails.py
+++ b/src/AppDetails.py
@@ -18,7 +18,7 @@ from .providers.providers_list import appimage_provider
 from .lib.async_utils import _async, idle, debounce
 from .lib.json_config import read_json_config, set_json_config, read_config_for_app, save_config_for_app, \
     remove_update_config
-from .lib.utils import url_is_valid, get_file_hash, get_application_window, show_message_dialog, gnu_naturalsize, check_internet
+from .lib.utils import url_is_valid, get_file_hash, get_application_window, show_message_dialog, gnu_naturalsize, check_internet, NO_CONNECTION_LABEL
 from .components.CustomComponents import CenteringBox, LabelStart
 from .components.AppDetailsConflictModal import AppDetailsConflictModal
 from .components.AdwEntryRowDefault import AdwEntryRowDefault
@@ -659,6 +659,20 @@ class AppDetails(Gtk.ScrolledWindow):
     @_async
     def check_updates(self):
         if not check_internet():
+            def _show_no_connection():
+                if self.update_url_save_btn:
+                    self.update_url_save_btn.set_label(NO_CONNECTION_LABEL)
+                    self.update_url_save_btn.add_css_class('destructive-action')
+                    self.update_url_save_btn.set_sensitive(True)
+
+            def _reset_btn():
+                if self.update_url_save_btn:
+                    self.update_url_save_btn.set_label(self.BTN_SAVE)
+                    self.update_url_save_btn.remove_css_class('destructive-action')
+                return GLib.SOURCE_REMOVE
+
+            GLib.idle_add(_show_no_connection)
+            GLib.timeout_add_seconds(3, _reset_btn)
             return
 
         manager = self.update_manager

--- a/src/InstalledAppsList.py
+++ b/src/InstalledAppsList.py
@@ -14,7 +14,7 @@ from .components.CustomComponents import NoAppsFoundRow
 from .components.AppListBoxItem import AppListBoxItem
 from .preferences import Preferences
 from .WelcomeScreen import WelcomeScreen
-from .lib.utils import get_application_window, check_internet
+from .lib.utils import get_application_window, check_internet, NO_CONNECTION_LABEL
 from .lib.async_utils import _async, idle
 from .models.UpdateManagerChecker import UpdateManagerChecker
 
@@ -143,6 +143,18 @@ class InstalledAppsList(Gtk.ScrolledWindow):
         global fetch_updates_cache
 
         if not check_internet():
+            def _show_no_connection():
+                self.updates_btn.set_label(NO_CONNECTION_LABEL)
+                self.updates_btn.add_css_class('destructive-action')
+                self.updates_btn.set_sensitive(True)
+
+            def _reset_btn():
+                self.updates_btn.set_label(self.CHECK_FOR_UPDATES_LABEL)
+                self.updates_btn.remove_css_class('destructive-action')
+                return GLib.SOURCE_REMOVE
+
+            GLib.idle_add(_show_no_connection)
+            GLib.timeout_add_seconds(3, _reset_btn)
             return
 
         logging.debug('Fetching for updates for all apps')

--- a/src/lib/utils.py
+++ b/src/lib/utils.py
@@ -280,16 +280,21 @@ def gnu_naturalsize(value, precision=1):
     # Return formatted string (e.g., 953.7M)
     return f"{v:.{precision}f} {suffixes[i]}"
 
-def check_internet(timeout=3):
-    try:
-        r = requests.get(
-            url='http://fedoraproject.org/static/hotspot.txt',
-            timeout=timeout
-        )
+NO_CONNECTION_LABEL = _('No Connection')
 
-        r.raise_for_status()
-    except Exception as e:
-        logging.warning(f"No internet connection detected")
-        return False
-    
-    return True
+def check_internet(timeout=3):
+    urls = [
+        'https://fedoraproject.org/static/hotspot.txt',
+        'http://fedoraproject.org/static/hotspot.txt',
+    ]
+
+    for url in urls:
+        try:
+            r = requests.get(url=url, timeout=timeout, allow_redirects=False)
+            if r.status_code < 400:
+                return True
+        except Exception:
+            continue
+
+    logging.warning("No internet connection detected")
+    return False


### PR DESCRIPTION
This PR improves the connection check (fixed #429)

- the connection check now first tries to connect via https and uses http as a fallback
- if the user checks for updates and the connection test fails the "check for updates" button turns red and shows "No Connection"
<img width="652" height="643" alt="image" src="https://github.com/user-attachments/assets/ee95d963-cf3c-48c5-aeaa-e92b809f8600" />

