### PR TITLE
Remove invalid import for NO_CONNECTION_LABEL

### DIFF
--- a/src/InstalledAppsList.py
+++ b/src/InstalledAppsList.py
@@ -5,7 +5,6 @@ import logging
 
 from .State import state
 from time import sleep
-from .lib.constants import NO_CONNECTION_LABEL
 from .providers.providers_list import appimage_provider
 from .providers.AppImageProvider import AppImageListElement
 from .models.AppListElement import InstalledStatus


### PR DESCRIPTION
Importing NO_CONNECTION_LABEL broke app start.

Fixes https://github.com/mijorus/gearlever/issues/432