### PR TITLE
Improve update management UX: distinguish "file not found" from "no updates"

### DIFF
--- a/src/AppDetails.py
+++ b/src/AppDetails.py
@@ -38,6 +38,7 @@ class AppDetails(Gtk.ScrolledWindow):
     CANCEL_UPDATE = _('Cancel update')
     UPDATE_FETCHING = _('Checking updates...')
     UPDATE_NOT_AVAIL_BTN_LABEL = _('No updates available')
+    UPDATE_NO_MATCH_BTN_LABEL = _('Release file not found')
     UPDATE_INFO_EMBEDDED = _('This application includes update information provided by the developer')
     UPDATE_INFO_NOT_EMBEDDED = _('Manage update details for this application')
 
@@ -664,6 +665,8 @@ class AppDetails(Gtk.ScrolledWindow):
         if is_updatable:
             logging.debug(f'{self.app_list_element.name} is_updatable')
             GLib.idle_add(lambda: self.update_action_button.set_label(self.UPDATE_BTN_LABEL))
+        elif is_updatable is None:
+            GLib.idle_add(lambda: self.update_action_button.set_label(self.UPDATE_NO_MATCH_BTN_LABEL))
         else:
             GLib.idle_add(lambda: self.update_action_button.set_label(self.UPDATE_NOT_AVAIL_BTN_LABEL))
 

--- a/src/models/CodebergUpdater.py
+++ b/src/models/CodebergUpdater.py
@@ -202,10 +202,10 @@ class CodebergUpdater(UpdateManager):
             allow_prereleases = self.allow_prereleases_row.get_active()
 
         if self.repo_url_row:
-            repo_url = self.repo_url_row.get_text()
+            repo_url = self.repo_url_row.get_text().strip()
 
         if self.repo_filename_row:
-            repo_filename = self.repo_filename_row.get_text()
+            repo_filename = self.repo_filename_row.get_text().strip()
 
         return {
             'allow_prereleases': allow_prereleases,

--- a/src/models/CodebergUpdater.py
+++ b/src/models/CodebergUpdater.py
@@ -154,12 +154,16 @@ class CodebergUpdater(UpdateManager):
         return download_asset
 
     def is_update_available(self):
+        config = self.get_config()
         target_asset = self.fetch_target_asset()
 
         if target_asset:
             old_size = os.path.getsize(self.el.file_path)
             is_size_different = target_asset['size'] != old_size
             return is_size_different
+
+        if config.get('repo_filename'):
+            return None
 
         return False
 

--- a/src/models/ForgejoUpdater.py
+++ b/src/models/ForgejoUpdater.py
@@ -159,12 +159,16 @@ class ForgejoUpdater(UpdateManager):
         return download_asset
 
     def is_update_available(self):
+        config = self.get_config()
         target_asset = self.fetch_target_asset()
 
         if target_asset:
             old_size = os.path.getsize(self.el.file_path)
             is_size_different = target_asset['size'] != old_size
             return is_size_different
+
+        if config.get('repo_filename'):
+            return None
 
         return False
 

--- a/src/models/ForgejoUpdater.py
+++ b/src/models/ForgejoUpdater.py
@@ -207,10 +207,10 @@ class ForgejoUpdater(UpdateManager):
             allow_prereleases = self.allow_prereleases_row.get_active()
 
         if self.repo_url_row:
-            repo_url = self.repo_url_row.get_text()
+            repo_url = self.repo_url_row.get_text().strip()
 
         if self.repo_filename_row:
-            repo_filename = self.repo_filename_row.get_text()
+            repo_filename = self.repo_filename_row.get_text().strip()
 
         return {
             'allow_prereleases': allow_prereleases,

--- a/src/models/GithubUpdater.py
+++ b/src/models/GithubUpdater.py
@@ -344,7 +344,7 @@ class GithubUpdater(UpdateManager):
             repo = self.repo_url_row.get_text().strip()
 
         if self.repo_filename_row:
-            repo_filename = self.repo_filename_row.get_text()
+            repo_filename = self.repo_filename_row.get_text().strip()
 
         return {
             'allow_prereleases': allow_prereleases,

--- a/src/models/GithubUpdater.py
+++ b/src/models/GithubUpdater.py
@@ -289,6 +289,10 @@ class GithubUpdater(UpdateManager):
                 is_size_different = target_asset['asset']['size'] != old_size
                 return is_size_different
 
+        config = self.get_config()
+        if config.get('repo_filename'):
+            return None
+
         return False
 
     def load_form_rows(self): 

--- a/src/models/GitlabUpdater.py
+++ b/src/models/GitlabUpdater.py
@@ -161,6 +161,9 @@ class GitlabUpdater(UpdateManager):
 
             return is_size_different
 
+        if self.get_config().get('repo_filename'):
+            return None
+
         return False
 
     def load_form_rows(self, embedded=None):

--- a/src/models/GitlabUpdater.py
+++ b/src/models/GitlabUpdater.py
@@ -189,10 +189,10 @@ class GitlabUpdater(UpdateManager):
         repo_filename = None
 
         if self.repo_url_row:
-            repo_url = self.repo_url_row.get_text()
+            repo_url = self.repo_url_row.get_text().strip()
 
         if self.repo_filename_row:
-            repo_filename = self.repo_filename_row.get_text()
+            repo_filename = self.repo_filename_row.get_text().strip()
 
         return {
             'repo_url': repo_url,

--- a/src/models/UpdateManager.py
+++ b/src/models/UpdateManager.py
@@ -28,7 +28,7 @@ class UpdateManager(ABC):
         pass
 
     @abstractmethod
-    def is_update_available(self) -> bool:
+    def is_update_available(self) -> 'bool | None':
         pass
 
     @abstractmethod


### PR DESCRIPTION
This PR improves UX when configuring update management. Sets the Update button to "Release file not found" instead of "No updates available" when the configured path does not match an AppImage. Giving user feedback that they have possible misconfiguration. 

Strips whitespace from the repository and filename fields. When you copy release file from GitHub it includes a space at the end.

Verified by user testing with AppImage configured to update from GitHub.