### PR TITLE
fix: make left button visible again when multi-update finishes

### DIFF
--- a/src/GearleverWindow.py
+++ b/src/GearleverWindow.py
@@ -237,6 +237,7 @@ class GearleverWindow(Adw.Window):
             self.left_button.set_visible(False)
         else:
             self.search_btn.set_visible(True)
+            self.left_button.set_visible(True)
             self.left_button.set_child(self.open_appimage_button_child)
 
         if in_apps_list:


### PR DESCRIPTION
This should fix the issue raised in #479 where the left button doesn't appear again when the multi-update finishes.

Fixes #479
Fixes #330 