### PR TITLE
fix: disable interpolation for config parser

### DIFF
--- a/src/lib/ini_config.py
+++ b/src/lib/ini_config.py
@@ -12,7 +12,7 @@ from gi.repository import GLib  # noqa
 
 class Config:
     path = os.path.join(GLib.get_user_config_dir(), 'gearlever.conf')
-    parser = configparser.ConfigParser()
+    parser = configparser.ConfigParser(interpolation=None)
 
     @staticmethod
     def return_boolean(v):


### PR DESCRIPTION
this is simply a pr for the fix mentioned in #487

resolves #487 