### PR TITLE
Add a grid view for installed apps alongside the existing list

### DIFF
--- a/data/it.mijorus.gearlever.gschema.xml
+++ b/data/it.mijorus.gearlever.gschema.xml
@@ -31,5 +31,8 @@
         <key name="block-unsafe-extractor" type="b">
             <default>true</default>
         </key>
+        <key name="installed-apps-view-mode" type="s">
+            <default>"list"</default>
+        </key>
     </schema>
 </schemalist>

--- a/src/AppDetails.py
+++ b/src/AppDetails.py
@@ -17,7 +17,7 @@ from .models.AppListElement import InstalledStatus
 from .providers.AppImageProvider import AppImageListElement, AppImageUpdateLogic
 from .providers.providers_list import appimage_provider
 from .lib.async_utils import _async, idle, debounce
-from .lib.utils import url_is_valid, get_file_hash, get_application_window, show_message_dialog, gnu_naturalsize, check_internet
+from .lib.utils import url_is_valid, get_file_hash, get_application_window, show_message_dialog, gnu_naturalsize, check_internet, show_remove_confirm_dialog as confirm_app_removal
 from .components.CustomComponents import CenteringBox, LabelStart
 from .components.AppDetailsConflictModal import AppDetailsConflictModal
 from .components.AdwEntryRowDefault import AdwEntryRowDefault
@@ -511,19 +511,7 @@ class AppDetails(Gtk.ScrolledWindow):
 
     @idle
     def show_remove_confirm_dialog(self):
-        dialog = Adw.MessageDialog(
-            transient_for=get_application_window(),
-            heading=_('Do you really want to remove this app?'),
-        )
-
-        dialog.add_response('cancel', _('Cancel'))
-        dialog.add_response('remove', _('Remove'))
-        dialog.set_response_appearance('remove', Adw.ResponseAppearance.DESTRUCTIVE)
-        dialog.set_close_response('cancel')
-        dialog.set_close_response('remove')
-        dialog.connect('response', self.on_remove_app_clicked)
-
-        dialog.present()
+        confirm_app_removal(self.on_remove_app_clicked)
 
     @idle
     def set_all_btn_sensitivity(self, s: bool):

--- a/src/InstalledAppsList.py
+++ b/src/InstalledAppsList.py
@@ -10,9 +10,10 @@ from .models.AppListElement import InstalledStatus
 from .components.FilterEntry import FilterEntry
 from .components.CustomComponents import NoAppsFoundRow
 from .components.AppListBoxItem import AppListBoxItem
+from .components.AppGridBoxItem import AppGridBoxItem
 from .preferences import Preferences
 from .WelcomeScreen import WelcomeScreen
-from .lib.utils import get_application_window, check_internet
+from .lib.utils import get_application_window, check_internet, show_message_dialog, show_remove_confirm_dialog
 from .lib.async_utils import _async, idle
 from .models.UpdateManagerChecker import UpdateManagerChecker
 from .models.Settings import Settings
@@ -47,7 +48,23 @@ class InstalledAppsList(Gtk.ScrolledWindow):
 
         self.installed_apps_list_slot.append(self.installed_apps_list)
 
+        self.installed_apps_grid = Gtk.FlowBox(
+            valign=Gtk.Align.START,
+            selection_mode=Gtk.SelectionMode.NONE,
+            homogeneous=True,
+            column_spacing=6,
+            row_spacing=6,
+            min_children_per_line=2,
+            max_children_per_line=30,
+        )
+        self.installed_apps_grid.connect('child-activated', self.on_activated_grid_child)
+
+        self.view_stack = Gtk.Stack(transition_type=Gtk.StackTransitionType.CROSSFADE)
+        self.view_stack.add_named(self.installed_apps_list_slot, 'list')
+        self.view_stack.add_named(self.installed_apps_grid, 'grid')
+
         self.installed_apps_list_rows: List[AppListBoxItem] = []
+        self.installed_apps_grid_rows: List[AppGridBoxItem] = []
         self.no_apps_found_row = NoAppsFoundRow(visible=False)
 
         # Create the filter search bar
@@ -76,12 +93,37 @@ class InstalledAppsList(Gtk.ScrolledWindow):
             css_classes=['suggested-action']
         )
 
+        # list/grid view switcher
+        saved_view_mode = Settings.settings.get_string('installed-apps-view-mode')
+
+        self.view_list_btn = Gtk.ToggleButton(
+            icon_name='view-list-symbolic',
+            tooltip_text=_('List view'),
+            active=(saved_view_mode != 'grid'),
+        )
+        self.view_grid_btn = Gtk.ToggleButton(
+            icon_name='view-grid-symbolic',
+            tooltip_text=_('Grid view'),
+            group=self.view_list_btn,
+            active=(saved_view_mode == 'grid'),
+        )
+
+        self.view_list_btn.connect('toggled', self.on_view_mode_toggled)
+        self.view_grid_btn.connect('toggled', self.on_view_mode_toggled)
+
+        view_mode_switcher = Gtk.Box(css_classes=['linked'])
+        view_mode_switcher.append(self.view_list_btn)
+        view_mode_switcher.append(self.view_grid_btn)
+
+        self.view_stack.set_visible_child_name('grid' if saved_view_mode == 'grid' else 'list')
+
         self.updates_btn.connect('clicked', self.on_fetch_updates_btn_clicked)
         self.update_all_btn.connect('clicked', self.on_update_all_btn_clicked)
+        title_row.append(view_mode_switcher)
         title_row.append(self.updates_btn)
         title_row.append(self.update_all_btn)
 
-        [self.main_box.append(el) for el in [title_row, self.installed_apps_list_slot]]
+        [self.main_box.append(el) for el in [title_row, self.view_stack, self.no_apps_found_row]]
 
         clamp = Adw.Clamp(child=self.main_box, maximum_size=clamp_size, margin_top=20, margin_bottom=20)
 
@@ -105,6 +147,18 @@ class InstalledAppsList(Gtk.ScrolledWindow):
         self.filter_entry.set_search_mode(False)
         self.emit('selected-app', row._app)
 
+    def on_activated_grid_child(self, flowbox, child: Gtk.FlowBoxChild):
+        self.filter_entry.set_search_mode(False)
+        self.emit('selected-app', child._app)
+
+    def on_view_mode_toggled(self, btn: Gtk.ToggleButton):
+        if not btn.get_active():
+            return
+
+        mode = 'grid' if btn is self.view_grid_btn else 'list'
+        self.view_stack.set_visible_child_name(mode)
+        Settings.settings.set_string('installed-apps-view-mode', mode)
+
     def trigger_search_mode(self):
         self.filter_entry.set_search_mode(
             not self.filter_entry.get_search_mode()
@@ -112,29 +166,41 @@ class InstalledAppsList(Gtk.ScrolledWindow):
 
     def refresh_list(self):
         self.installed_apps_list.remove_all()
+        self.installed_apps_grid.remove_all()
         self.updates_btn.set_label(self.CHECK_FOR_UPDATES_LABEL)
         self.installed_apps_list_rows = []
+        self.installed_apps_grid_rows = []
 
         installed: List[AppImageListElement] = appimage_provider.list_installed()
 
         for i in installed:
             list_row = AppListBoxItem(i, activatable=True, selectable=False, hexpand=True)
             list_row.set_update_version(i.version, i.size)
-
             list_row.load_icon()
             self.installed_apps_list_rows.append(list_row)
             self.installed_apps_list.append(list_row)
+
+            grid_row = AppGridBoxItem(i)
+            grid_row.set_update_version(i.version)
+            grid_row.load_icon()
+            grid_row.connect('launch-app', self.on_grid_item_launch)
+            grid_row.connect('update-app', self.on_grid_item_update)
+            grid_row.connect('remove-app', self.on_grid_item_remove)
+            self.installed_apps_grid_rows.append(grid_row)
+            self.installed_apps_grid.append(grid_row)
 
         if installed:
             self.container_stack.set_visible_child(self.clamp_container)
         else:
             self.container_stack.set_visible_child(self.placeholder)
 
-        self.installed_apps_list.append(self.no_apps_found_row)
         self.no_apps_found_row.set_visible(False)
-        
+
         self.installed_apps_list.set_sort_func(lambda r1, r2: self.sort_installed_apps_list(r1, r2))
         self.installed_apps_list.invalidate_sort()
+
+        self.installed_apps_grid.set_sort_func(lambda r1, r2: self.sort_installed_apps_list(r1, r2))
+        self.installed_apps_grid.invalidate_sort()
 
         self.update_all_btn.set_visible(False)
 
@@ -207,7 +273,7 @@ class InstalledAppsList(Gtk.ScrolledWindow):
 
     @idle
     def complete_updates_fetch(self, updatable_filepaths: list[str], updatable_apps: int, updates_available: int):
-        for row in self.installed_apps_list_rows:
+        for row in [*self.installed_apps_list_rows, *self.installed_apps_grid_rows]:
             if row._app.file_path in updatable_filepaths:
                 row.show_updatable_badge()
 
@@ -231,7 +297,7 @@ class InstalledAppsList(Gtk.ScrolledWindow):
         self.filter_query = widget.get_text()
         # self.installed_apps_list.invalidate_filter()
 
-        for row in self.installed_apps_list_rows:
+        for row in [*self.installed_apps_list_rows, *self.installed_apps_grid_rows]:
             if not getattr(row, 'force_show', False) and row._app.installed_status != InstalledStatus.INSTALLED:
                 row.set_visible(False)
                 continue
@@ -269,3 +335,32 @@ class InstalledAppsList(Gtk.ScrolledWindow):
     def on_open_welcome_screen(self, widget):
         tutorial = WelcomeScreen()
         tutorial.present(self)
+
+    def on_grid_item_launch(self, card, app: AppImageListElement):
+        appimage_provider.run(app)
+
+    @_async
+    def on_grid_item_update(self, card, app: AppImageListElement):
+        if appimage_provider.is_app_running(app):
+            GLib.idle_add(show_message_dialog, _('{app_name} is running, please close it before proceeding with the update').format(app_name=app.name))
+            return
+
+        manager = UpdateManagerChecker.check_url_for_app(app)
+        if not manager:
+            return
+
+        try:
+            appimage_provider.update_from_url(manager, app, status_cb=lambda s: None)
+        except Exception as e:
+            logging.error(e)
+            GLib.idle_add(show_message_dialog, str(e))
+
+        GLib.idle_add(self.refresh_list)
+
+    def on_grid_item_remove(self, card, app: AppImageListElement):
+        show_remove_confirm_dialog(self.on_grid_item_remove_confirm, app)
+
+    def on_grid_item_remove_confirm(self, dialog, response: str, app: AppImageListElement):
+        if response == 'remove':
+            appimage_provider.uninstall(app)
+            self.refresh_list()

--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -36,3 +36,13 @@
 .big-btn {
     padding: 10px;
 }
+
+.app-gridbox-item {
+    margin: 6px;
+    padding: 10px;
+}
+
+.grid-update-badge {
+    margin-top: -4px;
+    margin-right: -4px;
+}

--- a/src/components/AppGridBoxItem.py
+++ b/src/components/AppGridBoxItem.py
@@ -1,0 +1,120 @@
+from gi.repository import Gtk, Pango, GObject
+from typing import Optional
+
+from ..models.AppListElement import InstalledStatus
+from ..providers.AppImageProvider import AppImageListElement
+from ..providers.providers_list import appimage_provider
+
+
+class AppGridBoxItem(Gtk.FlowBoxChild):
+    __gsignals__ = {
+        "launch-app": (GObject.SIGNAL_RUN_FIRST, GObject.TYPE_NONE, (object, )),
+        "update-app": (GObject.SIGNAL_RUN_FIRST, GObject.TYPE_NONE, (object, )),
+        "remove-app": (GObject.SIGNAL_RUN_FIRST, GObject.TYPE_NONE, (object, )),
+    }
+
+    def __init__(self, list_element: AppImageListElement, **kwargs):
+        super().__init__(**kwargs)
+
+        self._app: AppImageListElement = list_element
+
+        box = Gtk.Box(
+            orientation=Gtk.Orientation.VERTICAL,
+            spacing=4,
+            halign=Gtk.Align.CENTER,
+            valign=Gtk.Align.CENTER,
+            css_classes=['app-gridbox-item'],
+            width_request=110,
+        )
+
+        self.image_container = Gtk.Box(halign=Gtk.Align.CENTER, valign=Gtk.Align.CENTER)
+
+        self.update_available_icon = Gtk.Image(
+            icon_name='gl-software-update-available-symbolic',
+            visible=False,
+            halign=Gtk.Align.END,
+            valign=Gtk.Align.START,
+            pixel_size=16,
+            css_classes=['grid-update-badge'],
+        )
+
+        self.image_overlay = Gtk.Overlay()
+        self.image_overlay.set_child(self.image_container)
+        self.image_overlay.add_overlay(self.update_available_icon)
+
+        box.append(self.image_overlay)
+        box.append(
+            Gtk.Label(
+                label=list_element.name,
+                halign=Gtk.Align.CENTER,
+                justify=Gtk.Justification.CENTER,
+                wrap=True,
+                wrap_mode=Pango.WrapMode.WORD_CHAR,
+                lines=2,
+                max_width_chars=15,
+                ellipsize=Pango.EllipsizeMode.END,
+                css_classes=['caption-heading'],
+            )
+        )
+
+        self.subtitle_label = Gtk.Label(
+            label='',
+            halign=Gtk.Align.CENTER,
+            max_width_chars=15,
+            ellipsize=Pango.EllipsizeMode.END,
+            css_classes=['caption', 'dim-label'],
+            visible=False,
+        )
+        box.append(self.subtitle_label)
+
+        # per-card quick actions (launch / update / remove)
+        self.launch_btn = Gtk.Button(
+            icon_name='media-playback-start-symbolic',
+            css_classes=['flat', 'circular'],
+            tooltip_text=_('Launch'),
+        )
+        self.launch_btn.connect('clicked', lambda *_: self.emit('launch-app', self._app))
+
+        self.update_btn = Gtk.Button(
+            icon_name='gl-software-update-available-symbolic',
+            css_classes=['flat', 'circular'],
+            tooltip_text=_('Update'),
+            visible=False,
+        )
+        self.update_btn.connect('clicked', lambda *_: self.emit('update-app', self._app))
+
+        self.remove_btn = Gtk.Button(
+            icon_name='gl-user-trash-symbolic',
+            css_classes=['flat', 'circular'],
+            tooltip_text=_('Remove'),
+        )
+        self.remove_btn.connect('clicked', lambda *_: self.emit('remove-app', self._app))
+
+        actions_box = Gtk.Box(
+            orientation=Gtk.Orientation.HORIZONTAL,
+            spacing=2,
+            halign=Gtk.Align.CENTER,
+        )
+        [actions_box.append(b) for b in [self.launch_btn, self.update_btn, self.remove_btn]]
+        box.append(actions_box)
+
+        self.set_child(box)
+
+        if self._app.installed_status in [InstalledStatus.UPDATING, InstalledStatus.INSTALLING]:
+            self.set_opacity(0.5)
+
+    def load_icon(self):
+        image = appimage_provider.get_icon(self._app)
+        self.set_icon(image)
+
+    def set_icon(self, image: Gtk.Image):
+        image.set_pixel_size(64)
+        self.image_container.append(image)
+
+    def set_update_version(self, text: Optional[str]):
+        self.subtitle_label.set_visible(bool(text))
+        self.subtitle_label.set_label(text or '')
+
+    def show_updatable_badge(self):
+        self.update_available_icon.set_visible(True)
+        self.update_btn.set_visible(True)

--- a/src/lib/utils.py
+++ b/src/lib/utils.py
@@ -171,6 +171,21 @@ def show_message_dialog(message, header=None, markup=False):
     dialog.present()
 
 
+def show_remove_confirm_dialog(on_response, *response_args):
+    dialog = Adw.MessageDialog(
+        transient_for=get_application_window(),
+        heading=_('Do you really want to remove this app?'),
+    )
+
+    dialog.add_response('cancel', _('Cancel'))
+    dialog.add_response('remove', _('Remove'))
+    dialog.set_response_appearance('remove', Adw.ResponseAppearance.DESTRUCTIVE)
+    dialog.set_close_response('cancel')
+    dialog.connect('response', on_response, *response_args)
+
+    dialog.present()
+
+
 def get_osinfo():
     os_release_file = "/run/host/os-release"
     if os.environ.get('FLATPAK_ID', None) is None:


### PR DESCRIPTION
PR for #491 

Adds a grid layout as an alternative to the current list, since the vertical list doesn't scale great once you've got more than a handful of AppImages installed.

What's new
- Toggle in the top bar to switch between list/grid, the choice sticks (saved in settings) across restarts
- Grid cards show the icon, name, version, and an update badge when one's available
- Each card has quick launch/update/remove buttons instead of having to open the details page for everything
- Filtering and the update-checker now work across both views, not just the list

